### PR TITLE
fix: don't try to serialize list values if list is not an array

### DIFF
--- a/plugin/src/schemas/serialize/serializeSchema.test.ts
+++ b/plugin/src/schemas/serialize/serializeSchema.test.ts
@@ -422,6 +422,33 @@ describe('serializeSchema', () => {
     ])
   })
 
+  test('should not try to serialize list values if list values are not an array', () => {
+    const schema = Schema.compile({
+      name: 'test',
+      types: [
+        defineType({
+          type: 'array',
+          name: 'list',
+          of: [{type: 'string'}],
+          options: {
+            list: new Promise(() => {}) as any, // Type usually only accepts array, but some plugins might use other types
+          },
+        }),
+      ],
+    })
+
+    const serializedTypes = serializeSchema(schema, {leanFormat: true})
+
+    expect(serializedTypes).toEqual([
+      {
+        name: 'list',
+        type: 'array',
+        of: [{type: 'string', name: 'string', title: 'String'}],
+        values: undefined,
+      },
+    ])
+  })
+
   test('should exclude truthy hidden and readonly', () => {
     const schema = Schema.compile({
       name: 'test',

--- a/plugin/src/schemas/serialize/serializeSchema.ts
+++ b/plugin/src/schemas/serialize/serializeSchema.ts
@@ -83,7 +83,7 @@ function getBaseFields(
           imagePromptField: imagePromptField,
         }
       : undefined,
-    values: type?.options?.list
+    values: Array.isArray(type?.options?.list)
       ? type?.options?.list.map((v: string | {value: string; title: string}) =>
           typeof v === 'string' ? v : v.value ?? `${v.title}`
         )


### PR DESCRIPTION
Closes #5.

Some plugins or user code might use other types. For instance, a list parameter being a promise, if the list values are being populated asynchronously.

This PR adds a check that a list parameter is actually an array before running `.map()` on it.