### PR TITLE
feat!: add strict ESM support

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "husky": "^8.0.3",
         "lint-staged": "^13.3.0",
         "prettier": "^3.2.5",
-        "prettier-plugin-packagejson": "^2.4.14"
+        "prettier-plugin-packagejson": "^2.4.14",
+        "rollup": "^4.14.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2622,11 +2623,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2638,11 +2639,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2654,11 +2655,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2670,11 +2671,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2686,11 +2687,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2702,11 +2703,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2718,11 +2719,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2734,11 +2735,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2750,11 +2751,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2766,11 +2767,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2782,11 +2783,11 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2798,11 +2799,11 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2814,11 +2815,11 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2830,11 +2831,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2846,11 +2847,11 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2862,11 +2863,11 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2878,11 +2879,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2894,11 +2895,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2910,11 +2911,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2926,11 +2927,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2942,11 +2943,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2958,11 +2959,11 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2974,11 +2975,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3265,7 +3266,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
       "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -3733,6 +3734,57 @@
       "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^22.0.0"
+      }
+    },
+    "node_modules/@optimize-lodash/rollup-plugin": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@optimize-lodash/rollup-plugin/-/rollup-plugin-4.0.4.tgz",
+      "integrity": "sha512-zcbnqx7oQWmGA3Xaf6I8m64+Rufebz4fnSuOHf0++aGqHdwbf19t5OdIebn8Deeb1DoyHbaWVezuTZyKw0vBJw==",
+      "dev": true,
+      "dependencies": {
+        "@optimize-lodash/transform": "3.0.3",
+        "@rollup/pluginutils": "~5.0.2"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "rollup": ">=2.x"
+      }
+    },
+    "node_modules/@optimize-lodash/rollup-plugin/node_modules/@rollup/pluginutils": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
+      "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@optimize-lodash/transform": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@optimize-lodash/transform/-/transform-3.0.3.tgz",
+      "integrity": "sha512-LeH2C2nYPfwKLQ1OX7jrfZOYTyRajOhhgoCdz47+5d2oBP8YKL/NknCAcDt2QkzLDLbtZ5QHhKZN56S2D/I1JA==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "2.x",
+        "magic-string": "0.30.x"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4411,6 +4463,12 @@
         "get-random-values-esm": "1.0.2",
         "lodash": "^4.17.21"
       }
+    },
+    "node_modules/@sanity/browserslist-config": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@sanity/browserslist-config/-/browserslist-config-1.0.3.tgz",
+      "integrity": "sha512-UkJuiTyROgPcxbvpHYyXwr+T88Np4eLzu3h05gMgeZ2hv3EM7g/4VMyng5HuA1JdPQPEdq8bmmfQDR+u4KC+TA==",
+      "dev": true
     },
     "node_modules/@sanity/cli": {
       "version": "3.36.4",
@@ -5747,6 +5805,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/rollup": {
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/rollup-plugin-preserve-directives": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-preserve-directives/-/rollup-plugin-preserve-directives-0.2.0.tgz",
+      "integrity": "sha512-KUwbBaFvD1zFIDNnOkR+u64sSod3m0l6q46/SzTOa4GTQ6hp6w0FRr2u7x99YkY9qhlna5panmTmuLWeJ/2KWw==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.0"
+      },
+      "peerDependencies": {
+        "rollup": "2.x || 3.x"
       }
     },
     "node_modules/@sanity/pkg-utils/node_modules/supports-color": {
@@ -7927,7 +8013,7 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10981,7 +11067,6 @@
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
       "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -20672,17 +20757,36 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
-      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
+      "integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=14.18.0",
+        "node": ">=18.0.0",
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.14.1",
+        "@rollup/rollup-android-arm64": "4.14.1",
+        "@rollup/rollup-darwin-arm64": "4.14.1",
+        "@rollup/rollup-darwin-x64": "4.14.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.14.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.14.1",
+        "@rollup/rollup-linux-arm64-musl": "4.14.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.14.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.14.1",
+        "@rollup/rollup-linux-x64-gnu": "4.14.1",
+        "@rollup/rollup-linux-x64-musl": "4.14.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.14.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.14.1",
+        "@rollup/rollup-win32-x64-msvc": "4.14.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -20703,18 +20807,6 @@
       "peerDependencies": {
         "esbuild": ">=0.18.0",
         "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-preserve-directives": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-preserve-directives/-/rollup-plugin-preserve-directives-0.2.0.tgz",
-      "integrity": "sha512-KUwbBaFvD1zFIDNnOkR+u64sSod3m0l6q46/SzTOa4GTQ6hp6w0FRr2u7x99YkY9qhlna5panmTmuLWeJ/2KWw==",
-      "dev": true,
-      "dependencies": {
-        "magic-string": "^0.30.0"
-      },
-      "peerDependencies": {
-        "rollup": "2.x || 3.x"
       }
     },
     "node_modules/rrweb-cssom": {
@@ -23154,7 +23246,7 @@
       "version": "5.30.3",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.3.tgz",
       "integrity": "sha512-STdUgOUx8rLbMGO9IOwHLpCqolkDITFFQSMYYwKE1N2lY6MVSaeoi10z/EhWxRc6ybqoVmKSkhKYH/XUpl7vSA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -23172,7 +23264,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/text-extensions": {
       "version": "2.4.0",
@@ -24486,40 +24578,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/vite-node/node_modules/rollup": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
-      "integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "1.0.5"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.14.1",
-        "@rollup/rollup-android-arm64": "4.14.1",
-        "@rollup/rollup-darwin-arm64": "4.14.1",
-        "@rollup/rollup-darwin-x64": "4.14.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.14.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.14.1",
-        "@rollup/rollup-linux-arm64-musl": "4.14.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.14.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.14.1",
-        "@rollup/rollup-linux-x64-gnu": "4.14.1",
-        "@rollup/rollup-linux-x64-musl": "4.14.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.14.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.14.1",
-        "@rollup/rollup-win32-x64-msvc": "4.14.1",
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/vite-node/node_modules/vite": {
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.8.tgz",
@@ -24939,6 +24997,21 @@
         "@esbuild/win32-arm64": "0.18.20",
         "@esbuild/win32-ia32": "0.18.20",
         "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/vite/node_modules/rollup": {
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/vitest": {
@@ -25438,40 +25511,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/vitest/node_modules/rollup": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
-      "integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "1.0.5"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.14.1",
-        "@rollup/rollup-android-arm64": "4.14.1",
-        "@rollup/rollup-darwin-arm64": "4.14.1",
-        "@rollup/rollup-darwin-x64": "4.14.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.14.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.14.1",
-        "@rollup/rollup-linux-arm64-musl": "4.14.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.14.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.14.1",
-        "@rollup/rollup-linux-x64-gnu": "4.14.1",
-        "@rollup/rollup-linux-x64-musl": "4.14.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.14.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.14.1",
-        "@rollup/rollup-win32-x64-msvc": "4.14.1",
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/vitest/node_modules/vite": {
@@ -26316,27 +26355,26 @@
       "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
-        "@sanity/icons": "^2.8.0",
+        "@sanity/icons": "^2.11.7",
         "@sanity/incompatible-plugin": "^1.0.4",
-        "@sanity/ui": "^2.0.2",
-        "date-fns": "^2.30.0",
-        "lodash.get": "^4.4.2",
-        "react-fast-compare": "^3.2.1",
-        "react-is": "^18.2.0",
-        "rxjs": "^7.8.0",
+        "@sanity/ui": "^2.1.0",
+        "date-fns": "^3.6.0",
+        "lodash": "^4.17.21",
+        "react-fast-compare": "^3.2.2",
+        "rxjs": "^7.8.1",
         "rxjs-exhaustmap-with-trailing": "^2.1.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.2.1",
         "@commitlint/config-conventional": "^19.1.0",
         "@rollup/plugin-image": "^3.0.3",
-        "@sanity/pkg-utils": "^2.4.10",
+        "@sanity/pkg-utils": "^6.1.0",
         "@sanity/plugin-kit": "^3.1.10",
         "@sanity/semantic-release-preset": "^4.1.7",
+        "@types/lodash": "^4.17.0",
         "@types/react": "^18.2.75",
         "@typescript-eslint/eslint-plugin": "^7.6.0",
         "@typescript-eslint/parser": "^7.6.0",
-        "date-fns": "^2.30.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-config-sanity": "^7.1.2",
@@ -26357,9 +26395,510 @@
         "node": ">=14"
       },
       "peerDependencies": {
+        "@sanity/mutator": "^3.36.4",
         "react": "^18",
-        "sanity": "^3.26",
-        "styled-components": "^5.2 || ^6.0.0"
+        "sanity": "^3.36.4",
+        "styled-components": "^6.1"
+      }
+    },
+    "plugin/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/android-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/android-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/android-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/darwin-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/linux-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/linux-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/linux-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/linux-loong64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/linux-s390x": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/linux-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/sunos-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/win32-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/win32-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@esbuild/win32-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "plugin/node_modules/@sanity/pkg-utils": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sanity/pkg-utils/-/pkg-utils-6.1.0.tgz",
+      "integrity": "sha512-p4RrSKEOcSCXc3mu4vthIbUCVfhmQ7q9ntQ4khbiTbUpVHaUFPAB1lI5nd+r0/YzgnydxamCLpiWCP9qtG1gHQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/types": "^7.24.0",
+        "@microsoft/api-extractor": "7.43.0",
+        "@microsoft/tsdoc-config": "^0.16.2",
+        "@optimize-lodash/rollup-plugin": "4.0.4",
+        "@rollup/plugin-alias": "^5.1.0",
+        "@rollup/plugin-babel": "^6.0.4",
+        "@rollup/plugin-commonjs": "^25.0.7",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "@rollup/plugin-replace": "^5.0.5",
+        "@rollup/plugin-terser": "^0.4.4",
+        "@sanity/browserslist-config": "^1.0.3",
+        "browserslist": "^4.23.0",
+        "cac": "^6.7.14",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.6.0",
+        "esbuild": "^0.20.2",
+        "esbuild-register": "^3.5.0",
+        "find-config": "^1.0.0",
+        "get-latest-version": "^5.1.0",
+        "git-url-parse": "^14.0.0",
+        "globby": "^11.1.0",
+        "jsonc-parser": "^3.2.1",
+        "mkdirp": "^3.0.1",
+        "outdent": "^0.8.0",
+        "parse-git-config": "^3.0.0",
+        "pkg-up": "^3.1.0",
+        "prettier": "^3.2.5",
+        "prettier-plugin-packagejson": "^2.4.14",
+        "pretty-bytes": "^5.6.0",
+        "prompts": "^2.4.2",
+        "rimraf": "^4.4.1",
+        "rollup": "^4.14.1",
+        "rollup-plugin-esbuild": "^6.1.1",
+        "rxjs": "^7.8.1",
+        "treeify": "^1.1.0",
+        "uuid": "^9.0.1",
+        "zod": "^3.22.4"
+      },
+      "bin": {
+        "pkg": "bin/pkg-utils.cjs",
+        "pkg-utils": "bin/pkg-utils.cjs"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "typescript": "5.4.x"
+      }
+    },
+    "plugin/node_modules/@sanity/pkg-utils/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "plugin/node_modules/@sanity/pkg-utils/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "plugin/node_modules/@sanity/pkg-utils/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "plugin/node_modules/@sanity/pkg-utils/node_modules/rimraf": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^9.2.0"
+      },
+      "bin": {
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "plugin/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "plugin/node_modules/brace-expansion": {
@@ -26369,6 +26908,96 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "plugin/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "plugin/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "plugin/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "plugin/node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "plugin/node_modules/esbuild": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
+      }
+    },
+    "plugin/node_modules/git-url-parse": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-14.0.0.tgz",
+      "integrity": "sha512-NnLweV+2A4nCvn4U/m2AoYu0pPKlsmhK9cknG7IMwsjFY1S2jxM+mAhsDxyxfCIGfGaD+dozsyX4b6vkYc83yQ==",
+      "dev": true,
+      "dependencies": {
+        "git-up": "^7.0.0"
       }
     },
     "plugin/node_modules/glob": {
@@ -26424,6 +27053,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "plugin/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "studio": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "husky": "^8.0.3",
     "lint-staged": "^13.3.0",
     "prettier": "^3.2.5",
-    "prettier-plugin-packagejson": "^2.4.14"
+    "prettier-plugin-packagejson": "^2.4.14",
+    "rollup": "^4.14.1"
   }
 }

--- a/plugin/package.config.ts
+++ b/plugin/package.config.ts
@@ -6,9 +6,6 @@ export default defineConfig({
   dist: 'dist',
   tsconfig: 'tsconfig.dist.json',
 
-  // Avoid ttyl, os and other node specific deps
-  external: ['@sanity/mutator'],
-
   // Remove this block to enable strict export validation
   extract: {
     rules: {

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -17,17 +17,13 @@
   },
   "license": "MIT",
   "author": "Sanity <hello@sanity.io>",
+  "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js",
-      "node": {
-        "module": "./dist/index.esm.js",
-        "import": "./dist/index.cjs.mjs"
-      },
-      "import": "./dist/index.esm.js",
-      "default": "./dist/index.esm.js"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
@@ -42,7 +38,7 @@
     "v2-incompatible.js"
   ],
   "scripts": {
-    "build": "run-s clean && plugin-kit verify-package --silent && pkg-utils build --strict && pkg-utils --strict",
+    "build": "run-s clean && pkg-utils build --strict && pkg-utils --strict",
     "clean": "rimraf dist",
     "format": "prettier --write --cache --ignore-unknown .",
     "link-watch": "plugin-kit link-watch",
@@ -54,27 +50,26 @@
     "release": "semantic-release"
   },
   "dependencies": {
-    "@sanity/icons": "^2.8.0",
+    "@sanity/icons": "^2.11.7",
     "@sanity/incompatible-plugin": "^1.0.4",
-    "@sanity/ui": "^2.0.2",
-    "date-fns": "^2.30.0",
-    "lodash.get": "^4.4.2",
-    "react-fast-compare": "^3.2.1",
-    "react-is": "^18.2.0",
-    "rxjs": "^7.8.0",
+    "@sanity/ui": "^2.1.0",
+    "date-fns": "^3.6.0",
+    "lodash": "^4.17.21",
+    "react-fast-compare": "^3.2.2",
+    "rxjs": "^7.8.1",
     "rxjs-exhaustmap-with-trailing": "^2.1.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.2.1",
     "@commitlint/config-conventional": "^19.1.0",
     "@rollup/plugin-image": "^3.0.3",
-    "@sanity/pkg-utils": "^2.4.10",
+    "@sanity/pkg-utils": "^6.1.0",
     "@sanity/plugin-kit": "^3.1.10",
     "@sanity/semantic-release-preset": "^4.1.7",
+    "@types/lodash": "^4.17.0",
     "@types/react": "^18.2.75",
     "@typescript-eslint/eslint-plugin": "^7.6.0",
     "@typescript-eslint/parser": "^7.6.0",
-    "date-fns": "^2.30.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-sanity": "^7.1.2",
@@ -92,9 +87,10 @@
     "vitest": "^1.4.0"
   },
   "peerDependencies": {
+    "@sanity/mutator": "^3.36.4",
     "react": "^18",
-    "sanity": "^3.26",
-    "styled-components": "^5.2 || ^6.0.0"
+    "sanity": "^3.36.4",
+    "styled-components": "^6.1"
   },
   "engines": {
     "node": ">=14"

--- a/plugin/src/_lib/form/DocumentForm.tsx
+++ b/plugin/src/_lib/form/DocumentForm.tsx
@@ -1,17 +1,18 @@
-import {Box, BoxProps, Flex, focusFirstDescendant, Spinner, Text} from '@sanity/ui'
-import React, {HTMLProps, useEffect, useMemo, useRef} from 'react'
+import {Box, type BoxProps, Flex, focusFirstDescendant, Spinner, Text} from '@sanity/ui'
+import type React from 'react'
+import {type HTMLProps, useEffect, useMemo, useRef} from 'react'
 import {tap} from 'rxjs/operators'
 import {
   createPatchChannel,
-  DocumentMutationEvent,
-  DocumentRebaseEvent,
+  type DocumentMutationEvent,
+  type DocumentRebaseEvent,
   FormBuilder,
   fromMutationPatches,
-  PatchMsg,
+  type PatchMsg,
   useDocumentPresence,
   useDocumentStore,
 } from 'sanity'
-import {useDocumentPane} from 'sanity/desk'
+import {useDocumentPane} from 'sanity/structure'
 
 import {assistFormId} from './constants'
 

--- a/plugin/src/assistDocument/AssistDocumentInput.tsx
+++ b/plugin/src/assistDocument/AssistDocumentInput.tsx
@@ -1,7 +1,7 @@
 import {useLayer} from '@sanity/ui'
 import {useMemo} from 'react'
-import {InputProps, ObjectInputProps, ObjectSchemaType} from 'sanity'
-import {useDocumentPane} from 'sanity/desk'
+import type {InputProps, ObjectInputProps, ObjectSchemaType} from 'sanity'
+import {useDocumentPane} from 'sanity/structure'
 
 import {ConnectFromRegion} from '../_lib/connector'
 import {assistFormId} from '../_lib/form/constants'

--- a/plugin/src/assistDocument/components/instruction/BackToInstructionsLink.tsx
+++ b/plugin/src/assistDocument/components/instruction/BackToInstructionsLink.tsx
@@ -1,7 +1,7 @@
 import {ArrowLeftIcon} from '@sanity/icons'
 import {Button} from '@sanity/ui'
 import {useCallback} from 'react'
-import {useDocumentPane} from 'sanity/desk'
+import {useDocumentPane} from 'sanity/structure'
 
 import {aiInspectorId} from '../../../assistInspector/constants'
 import {instructionParam} from '../../../types'

--- a/plugin/src/assistDocument/components/instruction/PromptInput.tsx
+++ b/plugin/src/assistDocument/components/instruction/PromptInput.tsx
@@ -1,10 +1,16 @@
 import {Box} from '@sanity/ui'
 import {useEffect} from 'react'
-import {ArrayOfObjectsInputProps, set, typed} from 'sanity'
-import styled from 'styled-components'
+import {type ArrayOfObjectsInputProps, set, typed} from 'sanity'
+import {styled} from 'styled-components'
 
 import {randomKey} from '../../../_lib/randomKey'
-import {ContextBlock, FieldRef, PromptBlock, PromptTextBlock, UserInputBlock} from '../../../types'
+import type {
+  ContextBlock,
+  FieldRef,
+  PromptBlock,
+  PromptTextBlock,
+  UserInputBlock,
+} from '../../../types'
 
 const PteMods = styled(Box)`
   & [data-testid='pt-editor__toolbar-card'] > div > div:last-child {

--- a/plugin/src/assistDocument/hooks/useAssistDocumentContextValue.tsx
+++ b/plugin/src/assistDocument/hooks/useAssistDocumentContextValue.tsx
@@ -1,10 +1,10 @@
 import {useMemo} from 'react'
-import {getPublishedId, ObjectSchemaType, useEditState} from 'sanity'
-import {useDocumentPane} from 'sanity/desk'
+import {getPublishedId, type ObjectSchemaType, useEditState} from 'sanity'
+import {useDocumentPane} from 'sanity/structure'
 
 import {useAiPaneRouter} from '../../assistInspector/helpers'
 import {fieldPathParam} from '../../types'
-import {AssistDocumentContextValue} from '../AssistDocumentContext'
+import type {AssistDocumentContextValue} from '../AssistDocumentContext'
 import {isDocAssistable} from '../RequestRunInstructionProvider'
 import {useStudioAssistDocument} from './useStudioAssistDocument'
 

--- a/plugin/src/assistFormComponents/validation/listItem.tsx
+++ b/plugin/src/assistFormComponents/validation/listItem.tsx
@@ -1,7 +1,7 @@
-import {Box, ButtonTone, Flex, MenuItem, Stack, Text} from '@sanity/ui'
+import {Box, type ButtonTone, Flex, MenuItem, Stack, Text} from '@sanity/ui'
 import {useCallback} from 'react'
-import {Path, ValidationMarker} from 'sanity'
-import styled from 'styled-components'
+import type {Path, ValidationMarker} from 'sanity'
+import {styled} from 'styled-components'
 
 interface ValidationListItemProps {
   marker: ValidationMarker

--- a/plugin/src/assistInspector/AssistInspector.tsx
+++ b/plugin/src/assistInspector/AssistInspector.tsx
@@ -2,18 +2,18 @@ import {ArrowRightIcon, CloseIcon, PlayIcon, RetryIcon} from '@sanity/icons'
 import {Box, Button, Card, Flex, Spinner, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo, useRef} from 'react'
 import {
-  DocumentInspectorProps,
+  type DocumentInspectorProps,
   PresenceOverlay,
   useEditState,
   VirtualizerScrollInstanceProvider,
 } from 'sanity'
 import {
   DocumentInspectorHeader,
-  DocumentPaneNode,
+  type DocumentPaneNode,
   DocumentPaneProvider,
   useDocumentPane,
-} from 'sanity/desk'
-import styled from 'styled-components'
+} from 'sanity/structure'
+import {styled} from 'styled-components'
 
 import {DocumentForm} from '../_lib/form'
 import {TypePathContext} from '../assistDocument/components/AssistDocumentForm'
@@ -31,7 +31,13 @@ import {InspectorOnboarding} from '../onboarding/InspectorOnboarding'
 import {inspectorOnboardingKey, useOnboardingFeature} from '../onboarding/onboardingStore'
 import {assistDocumentTypeName, fieldPathParam, instructionParam} from '../types'
 import {FieldTitle} from './FieldAutocomplete'
-import {FieldRef, getFieldTitle, useAiPaneRouter, useSelectedField, useTypePath} from './helpers'
+import {
+  type FieldRef,
+  getFieldTitle,
+  useAiPaneRouter,
+  useSelectedField,
+  useTypePath,
+} from './helpers'
 import {InstructionTaskHistoryButton} from './InstructionTaskHistoryButton'
 
 const CardWithShadowBelow = styled(Card)`

--- a/plugin/src/assistInspector/InstructionTaskHistoryButton.tsx
+++ b/plugin/src/assistInspector/InstructionTaskHistoryButton.tsx
@@ -18,15 +18,15 @@ import {
   useGlobalKeyDown,
   useLayer,
 } from '@sanity/ui'
-import {createElement, ForwardedRef, forwardRef, useCallback, useMemo, useState} from 'react'
-import {StatusButton, StatusButtonProps, typed, useClient} from 'sanity'
-import styled, {keyframes} from 'styled-components'
+import {createElement, type ForwardedRef, forwardRef, useCallback, useMemo, useState} from 'react'
+import {StatusButton, type StatusButtonProps, typed, useClient} from 'sanity'
+import {keyframes, styled} from 'styled-components'
 
 import {TimeAgo} from '../components/TimeAgo'
 import {maxHistoryVisibilityMs, pluginTitle} from '../constants'
 import {assistTasksStatusId} from '../helpers/ids'
 import {getInstructionTitle} from '../helpers/misc'
-import {AssistTasksStatus, InstructionTask, StudioInstruction, TaskEndedReason} from '../types'
+import type {AssistTasksStatus, InstructionTask, StudioInstruction, TaskEndedReason} from '../types'
 
 export interface InstructionTaskHistoryButtonProps {
   documentId?: string

--- a/plugin/src/assistInspector/helpers.ts
+++ b/plugin/src/assistInspector/helpers.ts
@@ -8,24 +8,24 @@ import {
   StringIcon,
 } from '@sanity/icons'
 import {extractWithPath} from '@sanity/mutator'
-import {ComponentType, useContext, useMemo} from 'react'
+import {type ComponentType, useContext, useMemo} from 'react'
 import {
-  ArraySchemaType,
+  type ArraySchemaType,
   isKeySegment,
   isObjectSchemaType,
-  ObjectSchemaType,
-  Path,
+  type ObjectSchemaType,
+  type Path,
   pathToString,
-  SanityDocumentLike,
-  SchemaType,
+  type SanityDocumentLike,
+  type SchemaType,
   stringToPath,
 } from 'sanity'
-import {type PaneRouterContextValue, usePaneRouter} from 'sanity/desk'
+import {type PaneRouterContextValue, usePaneRouter} from 'sanity/structure'
 
 import {SelectedFieldContext} from '../assistDocument/components/SelectedFieldContext'
 import {isAssistSupported} from '../helpers/assistSupported'
 import {isPortableTextArray, isType} from '../helpers/typeUtils'
-import {AssistInspectorRouteParams, documentRootKey, fieldPathParam} from '../types'
+import {type AssistInspectorRouteParams, documentRootKey, fieldPathParam} from '../types'
 
 export interface FieldRef {
   key: string

--- a/plugin/src/components/FadeInContent.tsx
+++ b/plugin/src/components/FadeInContent.tsx
@@ -1,5 +1,5 @@
-import {forwardRef, ReactElement, ReactNode} from 'react'
-import styled, {keyframes} from 'styled-components'
+import {forwardRef, type ReactElement, type ReactNode} from 'react'
+import {keyframes, styled} from 'styled-components'
 
 const fadeIn = keyframes`
   0% {

--- a/plugin/src/components/ImageContext.tsx
+++ b/plugin/src/components/ImageContext.tsx
@@ -1,6 +1,6 @@
 import {createContext, useEffect, useMemo, useState} from 'react'
-import {InputProps, pathToString, useSyncState} from 'sanity'
-import {usePaneRouter} from 'sanity/desk'
+import {type InputProps, pathToString, useSyncState} from 'sanity'
+import {usePaneRouter} from 'sanity/structure'
 
 import {useAssistDocumentContext} from '../assistDocument/AssistDocumentContext'
 import {useAiAssistanceConfig} from '../assistLayout/AiAssistanceConfigContext'

--- a/plugin/src/components/SafeValueInput.tsx
+++ b/plugin/src/components/SafeValueInput.tsx
@@ -1,7 +1,7 @@
 import {Box, Button, Card, ErrorBoundary, Flex, Stack, Text} from '@sanity/ui'
-import {ErrorInfo, PropsWithChildren, useCallback, useMemo, useState} from 'react'
-import {InputProps, isArraySchemaType, PatchEvent, unset} from 'sanity'
-import styled from 'styled-components'
+import {type ErrorInfo, type PropsWithChildren, useCallback, useMemo, useState} from 'react'
+import {type InputProps, isArraySchemaType, PatchEvent, unset} from 'sanity'
+import {styled} from 'styled-components'
 
 import {isPortableTextArray} from '../helpers/typeUtils'
 
@@ -25,12 +25,9 @@ export function ErrorWrapper(
   const {onChange} = props
   const [error, setError] = useState<Error | undefined>()
 
-  const catchError = useCallback(
-    (params: {error: Error; info: ErrorInfo}) => {
-      setError(params.error)
-    },
-    [setError],
-  )
+  const catchError = useCallback((params: {error: Error; info: ErrorInfo}) => {
+    setError(params.error)
+  }, [])
 
   const unsetValue = useCallback(() => {
     onChange(PatchEvent.from(unset()))

--- a/plugin/src/fieldActions/assistFieldActions.tsx
+++ b/plugin/src/fieldActions/assistFieldActions.tsx
@@ -8,7 +8,7 @@ import {
   typed,
   useCurrentUser,
 } from 'sanity'
-import {useDocumentPane} from 'sanity/desk'
+import {useDocumentPane} from 'sanity/structure'
 
 import {useAssistDocumentContext} from '../assistDocument/AssistDocumentContext'
 import {getIcon} from '../assistDocument/components/instruction/appearance/IconInput'

--- a/plugin/src/fieldActions/generateCaptionActions.tsx
+++ b/plugin/src/fieldActions/generateCaptionActions.tsx
@@ -1,8 +1,8 @@
 import {ImageIcon} from '@sanity/icons'
 import {Box, Spinner} from '@sanity/ui'
 import {useContext, useMemo} from 'react'
-import {DocumentFieldAction, DocumentFieldActionGroup, DocumentFieldActionItem} from 'sanity'
-import {useDocumentPane} from 'sanity/desk'
+import type {DocumentFieldAction, DocumentFieldActionGroup, DocumentFieldActionItem} from 'sanity'
+import {useDocumentPane} from 'sanity/structure'
 
 import {useAssistDocumentContext} from '../assistDocument/AssistDocumentContext'
 import {aiInspectorId} from '../assistInspector/constants'

--- a/plugin/src/onboarding/InspectorOnboarding.tsx
+++ b/plugin/src/onboarding/InspectorOnboarding.tsx
@@ -1,6 +1,6 @@
 import {SparklesIcon} from '@sanity/icons'
 import {Box, Button, Container, Flex, Stack, Text} from '@sanity/ui'
-import styled from 'styled-components'
+import {styled} from 'styled-components'
 
 import {releaseAnnouncementUrl} from '../constants'
 

--- a/plugin/src/presence/AssistAvatar.tsx
+++ b/plugin/src/presence/AssistAvatar.tsx
@@ -1,9 +1,9 @@
 import {purple} from '@sanity/color'
 import {SparklesIcon} from '@sanity/icons'
 import {Text} from '@sanity/ui'
-import {CSSProperties, useMemo} from 'react'
+import {type CSSProperties, useMemo} from 'react'
 import {useColorSchemeValue} from 'sanity'
-import styled, {keyframes} from 'styled-components'
+import {keyframes, styled} from 'styled-components'
 
 const Root = styled.span`
   display: block;

--- a/plugin/src/translate/getLanguageParams.ts
+++ b/plugin/src/translate/getLanguageParams.ts
@@ -1,5 +1,5 @@
-import get from 'lodash/get'
-import {SanityDocumentLike} from 'sanity'
+import {get} from 'lodash'
+import type {SanityDocumentLike} from 'sanity'
 
 export const getLanguageParams = (
   select: Record<string, string> | undefined,

--- a/plugin/src/translate/translateActions.tsx
+++ b/plugin/src/translate/translateActions.tsx
@@ -9,7 +9,7 @@ import type {
   DocumentFieldActionProps,
   ObjectSchemaType,
 } from 'sanity'
-import {useDocumentPane} from 'sanity/desk'
+import {useDocumentPane} from 'sanity/structure'
 
 import {useDraftDelayedTask} from '../assistDocument/RequestRunInstructionProvider'
 import {useAiAssistanceConfig} from '../assistLayout/AiAssistanceConfigContext'


### PR DESCRIPTION
@snorrees working on this I realise it's time for `@sanity/plugin-kit` to get some love. I'll make a PR on that repo with the new best practices we've developed for semantic-release, `@sanity/pkg-utils`, shipping ESM, using tsconfig's new `module: "Preserve"` config and more 🙌 

In this PR the goal is to enable strict ESM mode support. What is that? The ability to create a file like `test.mjs` that does this:

```js
import { assist } from "@sanity/assist";

console.log(await import.meta.resolve("@sanity/assist"), { assist });
```

And have it output `file:///node_modules/@sanity/assist/dist/index.mjs { assist: [Function (anonymous)] }`

Today, due to our esm wrapper pattern, it outputs:
```
file:///node_modules/@sanity/assist/dist/index.cjs.mjs { assist: [Function (anonymous)] }
```
The index.cjs.mjs file is re-exporting the cjs file. In other words, it takes Node out of ESM mode and resolves `@sanity/assist`, and all its deps, in CJS mode.
It's not enough to simply remove the re-export pattern:
```diff
-      "node": {
-        "module": "./dist/index.esm.js",
-        "import": "./dist/index.cjs.mjs"
-      },
```
This will create this output
```
file:///test.mjs:1
import { assist } from "@sanity/assist";
         ^^^^^^
SyntaxError: Named export 'assist' not found. The requested module '@sanity/assist' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from '@sanity/assist';
const { assist } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:132:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:214:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async loadESM (node:internal/process/esm_loader:28:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12)

Node.js v20.11.1
```

As you also need to use `.mjs` file endings:
```diff
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
```

And used dependencies (like in this case `date-fns`) has to be updated to support native ESM, or inlined by moving them out of `peerDependencies` and `dependencies` and into `devDependencies` (`@sanity/pkg-utils` marks packages in those two lists as `external`).

Why do we want native ESM mode? New environments like Remix + Vite are much stricter with how it deals with ESM, and doesn't support workarounds like `exports["."].node.import` that re-exports CJS. To support Studios embedding in those environments we have to be strictly ESM ready.