### PR TITLE
Fix incorrect function name in readme

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -682,7 +682,7 @@ The function should return `undefined` for all document members that should not 
 
 #### Default function
 
-The default `translationOutputs` is available using `import {defaultTranslationOutputs} from '@sanity/assist`.
+The default `translationOutputs` is available using `import {defaultLanguageOutputs} from '@sanity/assist`.
 
 #### Example
 


### PR DESCRIPTION
Hey! Been trying out the AI assist plugin. Am I understanding this correctly?

If I do a [code search for `defaultTranslationOutputs`](https://github.com/search?q=repo%3Asanity-io%2Fassist+defaultTranslationOutputs&type=code) the only results are documentation. Meanwhile a [code search for `defaultLanguageOutputs`](https://github.com/search?q=repo%3Asanity-io%2Fassist%20defaultLanguageOutputs&type=code) yields several results containing actual code.

Could it be that this is just the wrong name? If so then https://www.sanity.io/docs/ai-assist-content-translation also needs updating.