### PR TITLE
fix: update assistTasksStatusId to support version documents

### DIFF
--- a/plugin/src/helpers/ids.test.ts
+++ b/plugin/src/helpers/ids.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, test} from 'vitest'
 
-import {assistDocumentId} from './ids'
+import {assistDocumentId, assistTasksStatusId} from './ids'
 
 describe('ids', () => {
   test('assistDocumentId should replace illegal id chars with _', () => {
@@ -14,4 +14,15 @@ describe('ids', () => {
     const expected = testCases.map((testCase) => testCase.assistId)
     expect(outputs).toEqual(expected)
   })
+
+  test.each([
+    {documentId: 'foo', assistId: 'sanity.assist.status.foo'},
+    {documentId: 'drafts.foo', assistId: 'sanity.assist.status.foo'},
+    {documentId: 'versions.r12332.foo', assistId: 'sanity.assist.status.r12332.foo'},
+  ])(
+    "assistTasksStatusId should return the documentId with 'sanity.assist.status' prefix for $documentId",
+    ({documentId, assistId}) => {
+      expect(assistTasksStatusId(documentId)).toEqual(assistId)
+    },
+  )
 })

--- a/plugin/src/helpers/ids.ts
+++ b/plugin/src/helpers/ids.ts
@@ -1,3 +1,5 @@
+import {getPublishedId, getVersionFromId, isVersionId} from 'sanity'
+
 import {assistDocumentIdPrefix, assistDocumentStatusIdPrefix} from '../types'
 
 const illegalIdChars = /[^a-zA-Z0-9._-]/g
@@ -11,5 +13,15 @@ export function assistDocumentId(documentType: string) {
 }
 
 export function assistTasksStatusId(documentId: string) {
-  return `${assistDocumentStatusIdPrefix}${publicId(documentId)}`
+  if (isVersionId(documentId)) {
+    // Creates an id: sanity.assist.status.<versionName>.<documentId>
+    return [
+      assistDocumentStatusIdPrefix,
+      getVersionFromId(documentId),
+      getPublishedId(documentId),
+    ].join('.')
+  }
+
+  // Creates an id: sanity.assist.status<documentId>
+  return [assistDocumentStatusIdPrefix, getPublishedId(documentId)].join('.')
 }

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -3,7 +3,7 @@ import {PortableTextBlock, PortableTextMarkDefinition, PortableTextSpan} from '@
 
 //id prefixes
 export const assistDocumentIdPrefix = 'sanity.assist.schemaType.'
-export const assistDocumentStatusIdPrefix = 'sanity.assist.status.'
+export const assistDocumentStatusIdPrefix = 'sanity.assist.status'
 export const assistSchemaIdPrefix = 'sanity.assist.schema.'
 
 // type names


### PR DESCRIPTION
Updates `assistStatusTaskId` to follow the new id rules added to content lake. Ids cannot have a suffix if they are using the keyword version

To test it, you need to use the corel version of the studio:
Run the following commands
```bash
npx npm-check-updates --target=@corel --upgrade --deep --removeRange sanity @sanity/cli @sanity/vision @sanity/types @sanity/util @sanity/block-tools 
npm i 
```