### PR TITLE
fix: update README release section

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -844,7 +844,7 @@ on how to run this plugin with hotreload in the studio.
 
 ### Release new version
 
-Run ["CI & Release" workflow](https://github.com/sanity-io/sanity/actions/workflows/main.yml).
+Run ["CI & Release" workflow](https://github.com/sanity-io/assist/actions/workflows/main.yml).
 Make sure to select the main branch and check "Release new version".
 
 Semantic release will only release on configured branches, so it is safe to run release on any branch.


### PR DESCRIPTION
Replaces the **CI & Release" workflow** link in the readme