### PR TITLE
fix: `useSyncState` `version` argument type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
       "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "license": "MIT",
       "dependencies": {
         "@actions/exec": "^1.1.1",
         "@actions/http-client": "^2.0.1"
@@ -36,6 +37,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
       "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "license": "MIT",
       "dependencies": {
         "@actions/io": "^1.0.1"
       }
@@ -44,6 +46,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.0.tgz",
       "integrity": "sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==",
+      "license": "MIT",
       "dependencies": {
         "@actions/http-client": "^2.2.0",
         "@octokit/core": "^5.0.1",
@@ -55,6 +58,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
       "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
@@ -63,7 +67,8 @@
     "node_modules/@actions/io": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -1615,6 +1620,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.25.9.tgz",
       "integrity": "sha512-8D43jXtGsYmEeDvm4MWHYUpWf8iiXgWYx3fW7E7Wb7Oe6FWqJPl5K6TuFW0dOwNZzEE5rjlaSJYH9JjrUKJszA==",
+      "license": "MIT",
       "dependencies": {
         "clone-deep": "^4.0.1",
         "find-cache-dir": "^2.0.0",
@@ -2782,6 +2788,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       }
@@ -3283,6 +3290,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
       "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       }
@@ -3291,6 +3299,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
       "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -3308,6 +3317,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
       "integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
@@ -3320,6 +3330,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
       "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/request": "^8.3.0",
         "@octokit/types": "^13.0.0",
@@ -3338,6 +3349,7 @@
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.1.tgz",
       "integrity": "sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^12.6.0"
       },
@@ -3351,12 +3363,14 @@
     "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
       "version": "12.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
       "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
       }
@@ -3365,6 +3379,7 @@
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
       "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^12.6.0"
       },
@@ -3378,12 +3393,14 @@
     "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "license": "MIT"
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
       "version": "12.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
       "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
       }
@@ -3392,6 +3409,7 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
       "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^9.0.1",
         "@octokit/request-error": "^5.1.0",
@@ -3406,6 +3424,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
       "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^13.1.0",
         "deprecation": "^2.0.0",
@@ -3508,74 +3527,13 @@
         "node": ">=12"
       }
     },
-    "node_modules/@portabletext/editor": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-1.20.0.tgz",
-      "integrity": "sha512-2Vq3AU1zHcMxa+ayqVokCd2714K9/TrGbU8R7xaioCj5VojuTmVHz8OfxbKJzjMiDSBd5Pk7KclIC80nQuyhlQ==",
-      "dependencies": {
-        "@portabletext/patches": "1.1.1",
-        "@xstate/react": "^5.0.1",
-        "debug": "^4.3.4",
-        "get-random-values-esm": "^1.0.2",
-        "lodash": "^4.17.21",
-        "lodash.startcase": "^4.4.0",
-        "react-compiler-runtime": "19.0.0-beta-55955c9-20241229",
-        "slate": "0.112.0",
-        "slate-dom": "^0.111.0",
-        "slate-react": "0.112.0",
-        "use-effect-event": "^1.0.2",
-        "xstate": "^5.19.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@sanity/block-tools": "^3.68.3",
-        "@sanity/schema": "^3.68.3",
-        "@sanity/types": "^3.68.3",
-        "react": "^16.9 || ^17 || ^18 || ^19",
-        "rxjs": "^7.8.1"
-      }
-    },
-    "node_modules/@portabletext/editor/node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@portabletext/editor/node_modules/slate-react": {
-      "version": "0.112.0",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.112.0.tgz",
-      "integrity": "sha512-LoHb/XXnI5uf+n2hnjDKjWb3D+H3lGIg16N7Zzm1nHhhXm3NzwoKOTbzdKOMLdt2+tnhTaHpSxYfT7zZ+wdzUw==",
-      "dependencies": {
-        "@juggle/resize-observer": "^3.4.0",
-        "direction": "^1.0.4",
-        "is-hotkey": "^0.2.0",
-        "is-plain-object": "^5.0.0",
-        "lodash": "^4.17.21",
-        "scroll-into-view-if-needed": "^3.1.0",
-        "tiny-invariant": "1.3.1"
-      },
-      "peerDependencies": {
-        "react": ">=18.2.0",
-        "react-dom": ">=18.2.0",
-        "slate": ">=0.99.0",
-        "slate-dom": ">=0.110.2"
-      }
-    },
-    "node_modules/@portabletext/editor/node_modules/tiny-invariant": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
-    },
     "node_modules/@portabletext/patches": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@portabletext/patches/-/patches-1.1.1.tgz",
-      "integrity": "sha512-FXeVdLvSJ3JmZzS0dbxEFJZXplFo7K27/Twv0/dX/l86tfhhUkDSqaTlWcigxuibvohjdEYp2mB8Ucgao/JzIQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@portabletext/patches/-/patches-1.1.2.tgz",
+      "integrity": "sha512-ENGxLD+AJc2Uq2GfDCNmeU/9dT50VYBMX5zKYyPVw2/OYDEpLYDlEZBjh0v0RqEuE2ecUu+eBaHf4PE6C0CoQQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sanity/diff-match-patch": "^3.1.2",
+        "@sanity/diff-match-patch": "^3.2.0",
         "lodash": "^4.17.21"
       }
     },
@@ -3594,10 +3552,24 @@
         "react": "^17 || ^18 || >=19.0.0-0"
       }
     },
+    "node_modules/@portabletext/to-html": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@portabletext/to-html/-/to-html-2.0.14.tgz",
+      "integrity": "sha512-wW2et59PoOT/mc56C4U3z+DKAx1yjieN/gp2q9szTfTwusMpb6mclR9+EPIfGrcQWdwGn6PEN7nxVFXnqlZ/0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/toolkit": "^2.0.17",
+        "@portabletext/types": "^2.0.13"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/@portabletext/toolkit": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-2.0.16.tgz",
-      "integrity": "sha512-aBvnD8MscoAlEIuZBn0Aksd+oCuoMGFOT3CtHIgRBaac0Vu4YnnMUF45xo/B/T5vmwWcnDXoJEJdn+SKDg1m+A==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-2.0.17.tgz",
+      "integrity": "sha512-5wj+oUaCmHm9Ay1cytPmT1Yc0SrR1twwUIc0qNQ3MtaXaNMPw99Gjt1NcA34yfyKmEf/TAB2NiiT72jFxdddIQ==",
+      "license": "MIT",
       "dependencies": {
         "@portabletext/types": "^2.0.13"
       },
@@ -4208,42 +4180,30 @@
         "rxjs": "^7.0.0"
       }
     },
-    "node_modules/@sanity/block-tools": {
-      "version": "3.69.0",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.69.0.tgz",
-      "integrity": "sha512-KCMXPt6apZ/vE6PZ/6gr8LRS9Co/iCSJY5rDlr2dnonjYrMXs7Nl+olWCpCGLrwhu5FB8szUAQwVwJ7C6W1TaA==",
-      "dependencies": {
-        "@sanity/types": "3.69.0",
-        "get-random-values-esm": "1.0.2",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "@types/react": "18 || 19"
-      }
-    },
     "node_modules/@sanity/browserslist-config": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@sanity/browserslist-config/-/browserslist-config-1.0.5.tgz",
       "integrity": "sha512-so+/UtCge8t1jq509hH0otbbptRz0zM/Aa0dh5MhMD7HGT6n2igWIL2VWH/9QR9e77Jn3dJsjz23mW1WCxT+sg=="
     },
     "node_modules/@sanity/cli": {
-      "version": "3.69.0",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.69.0.tgz",
-      "integrity": "sha512-2lntlilK8m8+dRBkEyS+SbTbx5uMhOZomH7FdlBi6+V1O/CrVjwdl1anEirzal2wKqM8sf8cgU2nTEjo3XMrGg==",
+      "version": "3.74.1",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.74.1.tgz",
+      "integrity": "sha512-Sny5RzUDUy745eKAvWXkEwEUqYrjiWEej6R979d0kixu16FMXyIbq1PaXbFdoHJKwlVNos6BVvCskqbHMmBDtQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.23.5",
-        "@sanity/client": "^6.24.1",
-        "@sanity/codegen": "3.69.0",
+        "@sanity/client": "^6.27.2",
+        "@sanity/codegen": "3.74.1",
         "@sanity/telemetry": "^0.7.7",
-        "@sanity/template-validator": "^2.0.0",
-        "@sanity/util": "3.69.0",
+        "@sanity/template-validator": "^2.4.0",
+        "@sanity/util": "3.74.1",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
         "decompress": "^4.2.0",
         "esbuild": "0.21.5",
         "esbuild-register": "^3.5.0",
-        "get-it": "^8.6.5",
-        "groq-js": "^1.14.2",
+        "get-it": "^8.6.7",
+        "groq-js": "^1.15.0",
         "pkg-dir": "^5.0.0",
         "prettier": "^3.3.0",
         "semver": "^7.3.5",
@@ -4263,6 +4223,7 @@
       "cpu": [
         "ppc64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -4278,6 +4239,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -4293,6 +4255,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -4308,6 +4271,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -4323,6 +4287,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4338,6 +4303,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4353,6 +4319,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -4368,6 +4335,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -4383,6 +4351,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4398,6 +4367,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4413,6 +4383,7 @@
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4428,6 +4399,7 @@
       "cpu": [
         "loong64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4443,6 +4415,7 @@
       "cpu": [
         "mips64el"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4458,6 +4431,7 @@
       "cpu": [
         "ppc64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4473,6 +4447,7 @@
       "cpu": [
         "riscv64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4488,6 +4463,7 @@
       "cpu": [
         "s390x"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4503,6 +4479,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4518,6 +4495,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -4533,6 +4511,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -4548,6 +4527,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -4563,6 +4543,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4578,6 +4559,7 @@
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4593,6 +4575,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4605,6 +4588,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4619,6 +4603,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4635,6 +4620,7 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4671,6 +4657,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4682,17 +4669,19 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
+      "license": "ISC",
       "dependencies": {
         "builtins": "^1.0.3"
       }
     },
     "node_modules/@sanity/client": {
-      "version": "6.24.2",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.24.2.tgz",
-      "integrity": "sha512-0PnU2AkdOgPPziz1pzuXG09mHH5jBOSA/YaNAk14cu/Y0Nx48SpMjHvBrUk10Vg+cd4yXX+g7THKcuqk+909CQ==",
+      "version": "6.27.2",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.27.2.tgz",
+      "integrity": "sha512-x5KaN5atPnEFa3GGSH3YKSAYh1MAECvEs9o+NSLd5W19imxvSxPquQBv0Q60Zdsg6iaTJPAAa79Ak5Xyg2FHvA==",
+      "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
-        "get-it": "^8.6.5",
+        "get-it": "^8.6.7",
         "rxjs": "^7.0.0"
       },
       "engines": {
@@ -4824,9 +4813,10 @@
       }
     },
     "node_modules/@sanity/codegen": {
-      "version": "3.69.0",
-      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.69.0.tgz",
-      "integrity": "sha512-zV6LKciEpTJGxXieIMp6LtvD5dq7LQHLuwpW1iiLyQ2Cgb7yd8w9sSWPICd/d3YV+7eIPDQUoXmHe2JCpdBsuA==",
+      "version": "3.74.1",
+      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.74.1.tgz",
+      "integrity": "sha512-hPCWjQR6UHUyH/IslN9WYwPQCb9ckj8NGiqMPSZupWhjAMzHytdK7QeBdRAF+1wwuJ5d082N5bv+2x8AXyNeKA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/generator": "^7.23.6",
@@ -4838,8 +4828,8 @@
         "@babel/types": "^7.23.9",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
-        "groq": "3.69.0",
-        "groq-js": "^1.14.2",
+        "groq": "3.74.1",
+        "groq-js": "^1.15.0",
         "json5": "^2.2.3",
         "tsconfig-paths": "^4.2.0",
         "zod": "^3.22.4"
@@ -4857,22 +4847,24 @@
       }
     },
     "node_modules/@sanity/comlink": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@sanity/comlink/-/comlink-2.0.4.tgz",
-      "integrity": "sha512-ODjmZZJ4a4hiSK4TaQk2ysppIweIj6UNZ7o+fAkh7hotwcLxh+qTo8Rpb5yW2UfqGSAWTQDMcta9/4HAMWGfUA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/comlink/-/comlink-3.0.1.tgz",
+      "integrity": "sha512-I1F57GKL69xoJUF9/4XTMvXFJZ7BnaFmTBIaiRvXaovJEZ677p5f+UkURPG/dd9L63+OnTV0SNmhTjIIzNexdw==",
+      "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.1",
-        "uuid": "^11.0.4",
-        "xstate": "^5.19.1"
+        "uuid": "^11.0.5",
+        "xstate": "^5.19.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sanity/diff": {
-      "version": "3.69.0",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.69.0.tgz",
-      "integrity": "sha512-RihrjX06Aen30PTReGKONys9dW/rkvFmVhT3aoIKoPci1y2/xt6LMn/v7t565g5yN5Fes2RHVy61p33m7us0Mw==",
+      "version": "3.74.1",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.74.1.tgz",
+      "integrity": "sha512-dtjJNWcjt8JLZab62WQLFDyfIT+Gbjea0vYP73p91mnBWssaZv2XvP3dNoHVP8tl989quo0q6DqL8Q/XGr1Vmw==",
+      "license": "MIT",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1"
       },
@@ -4881,9 +4873,10 @@
       }
     },
     "node_modules/@sanity/diff-match-patch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@sanity/diff-match-patch/-/diff-match-patch-3.1.2.tgz",
-      "integrity": "sha512-jW2zqnnV3cLXy7exOKbqaWJPb15rFSQGseAhlPljzbg5CP0hrujk0TwYpsNMz2xwTELOk1JkBUINQYbPE4TmaA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@sanity/diff-match-patch/-/diff-match-patch-3.2.0.tgz",
+      "integrity": "sha512-4hPADs0qUThFZkBK/crnfKKHg71qkRowfktBljH2UIxGHHTxIzt8g8fBiXItyCjxkuNy+zpYOdRMifQNv8+Yww==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       }
@@ -5475,12 +5468,13 @@
       }
     },
     "node_modules/@sanity/insert-menu": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@sanity/insert-menu/-/insert-menu-1.0.18.tgz",
-      "integrity": "sha512-Hi3pVKMDQLeN/WDaRwsYyfWs9Hl6NjBhecutC17ucmILIBkymToLio5o6oQY9uAPAE/1tTOy1Xo32Uc/xqGCzw==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@sanity/insert-menu/-/insert-menu-1.0.20.tgz",
+      "integrity": "sha512-oYhGCerabMOJBU47ukjY5Hq6g87yHlN8Xr/HaqNLGG7ustGaT6cWA4UMaDuWd980qbWeC3s9Ph6cKRT/Sy8JtA==",
+      "license": "MIT",
       "dependencies": {
-        "@sanity/icons": "^3.5.5",
-        "@sanity/ui": "^2.10.12",
+        "@sanity/icons": "^3.5.7",
+        "@sanity/ui": "^2.11.4",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -5516,6 +5510,7 @@
       "version": "2.1.13",
       "resolved": "https://registry.npmjs.org/@sanity/logos/-/logos-2.1.13.tgz",
       "integrity": "sha512-PKAbPbM4zn+6wHYjCVwuhmlZnFqyZ9lT/O7OT3BVd2SGAqXoZTimfBOHrVPifytuazdoQ1T2M5eYJTtW/VXLyA==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       },
@@ -5525,18 +5520,19 @@
       }
     },
     "node_modules/@sanity/migrate": {
-      "version": "3.69.0",
-      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-3.69.0.tgz",
-      "integrity": "sha512-4itMULmljybWSBSKq3j9Bu1nKJY/f3W2bhyskZsAyHqMk7MMiUKW0sNEHONrlgB66Spa/IVModN3EIUlY5Z8Nw==",
+      "version": "3.74.1",
+      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-3.74.1.tgz",
+      "integrity": "sha512-NsA28RKztkx3TQlu4c7/YFer82vhMK2rvZeckC2kYLoAoscu4x2voVOL0v1sEieOLRVGMca0TXMV3ngzbdnN3A==",
+      "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^6.24.1",
-        "@sanity/mutate": "^0.11.1",
-        "@sanity/types": "3.69.0",
-        "@sanity/util": "3.69.0",
+        "@sanity/client": "^6.27.2",
+        "@sanity/mutate": "^0.12.1",
+        "@sanity/types": "3.74.1",
+        "@sanity/util": "3.74.1",
         "arrify": "^2.0.1",
         "debug": "^4.3.4",
         "fast-fifo": "^1.3.2",
-        "groq-js": "^1.14.2",
+        "groq-js": "^1.15.0",
         "p-map": "^7.0.1"
       },
       "engines": {
@@ -5547,6 +5543,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
       "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -5555,16 +5552,18 @@
       }
     },
     "node_modules/@sanity/mutate": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/mutate/-/mutate-0.11.1.tgz",
-      "integrity": "sha512-72chdEK8s9h1BLE/n7tOkCOGnrfFV/cH1fpvH/PpcxhpUY7wg6vvL7/durpXLEchWCO1ToS5DcFrCfmy1iKOrw==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@sanity/mutate/-/mutate-0.12.1.tgz",
+      "integrity": "sha512-SuOpMOEwcTcE5fFHpy44qVuGs8NeBAOF8wwN5DYz0Jl4MJZWGsUS81YUeFwQl0XqBZpfiLVzwutp1KYCZPuqUQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^6.22.3",
+        "@sanity/client": "^6.24.1",
         "@sanity/diff-match-patch": "^3.1.1",
+        "@sanity/uuid": "^3.0.2",
         "hotscript": "^1.0.13",
         "lodash": "^4.17.21",
-        "mendoza": "^3.0.7",
-        "nanoid": "^5.0.7",
+        "mendoza": "^3.0.8",
+        "nanoid": "^5.0.9",
         "rxjs": "^7.8.1"
       },
       "engines": {
@@ -5581,6 +5580,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.js"
       },
@@ -5589,12 +5589,13 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.69.0",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.69.0.tgz",
-      "integrity": "sha512-ZeYghYVvS4rreFvPh2VD5029GPsyVhD0WXKua+iuDeot7tRoyZ/RdvUamw1k/sNatmxVkYLYP3vEltuU8cPxtw==",
+      "version": "3.74.1",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.74.1.tgz",
+      "integrity": "sha512-Bvy5dRCoemV4K3TQKWqSfoC+P6vbd26dmktiqiS/IFtj83HQp0bh5LBAPUt/ZUTdfSV1bpeTfuzQELTvpXkTwA==",
+      "license": "MIT",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1",
-        "@sanity/types": "3.69.0",
+        "@sanity/types": "3.74.1",
         "@sanity/uuid": "^3.0.1",
         "debug": "^4.3.4",
         "lodash": "^4.17.21"
@@ -6734,37 +6735,27 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sanity/presentation": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.20.1.tgz",
-      "integrity": "sha512-w45QJs8HrVIodSVpIKPwb3wizWSwUeFPMDkqwi90LZ6JXYaji9NjIBDEWxdwAli1RPU01UTEWyzRBfSpqP+nwA==",
+    "node_modules/@sanity/presentation-comlink": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@sanity/presentation-comlink/-/presentation-comlink-1.0.5.tgz",
+      "integrity": "sha512-R3SN7rckwhnpWAIbm0KzTKQD3F1Dss/BXlchK0MHEmVRWKIylnfHBzSEuOAq910HrZnRGkeUvwjtxHT2gASDYw==",
+      "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^6.24.1",
-        "@sanity/comlink": "2.0.4",
-        "@sanity/icons": "^3.5.7",
-        "@sanity/logos": "^2.1.13",
-        "@sanity/preview-url-secret": "2.0.5",
-        "@sanity/ui": "^2.11.0",
-        "@sanity/uuid": "3.0.2",
-        "fast-deep-equal": "3.1.3",
-        "framer-motion": "^11.16.0",
-        "lodash": "^4.17.21",
-        "mendoza": "3.0.8",
-        "mnemonist": "0.39.8",
-        "path-to-regexp": "^6.3.0",
-        "react-compiler-runtime": "19.0.0-beta-55955c9-20241229",
-        "rxjs": "^7.8.1",
-        "suspend-react": "0.1.3",
-        "use-effect-event": "^1.0.2"
+        "@sanity/comlink": "^3.0.1",
+        "@sanity/visual-editing-types": "^1.0.5"
       },
       "engines": {
-        "node": ">=16.14"
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@sanity/client": "^6.27.2"
       }
     },
     "node_modules/@sanity/preview-url-secret": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@sanity/preview-url-secret/-/preview-url-secret-2.0.5.tgz",
-      "integrity": "sha512-YWExuJ/Z0CW37vYdiouE9A/NAN3QEewZL6qu6IohXqVY6wDDT0b9ubetTR4Op1kzmK6WbPGj79aiHrPubrM70A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@sanity/preview-url-secret/-/preview-url-secret-2.1.4.tgz",
+      "integrity": "sha512-D66VcYbGGXIkF4VQrvWo61l921LdyHKZgg5PYH0ZHcAE/wTXrMIM93I70jOp1DpN913c0vJ1sLxbLCbrEk7n8Q==",
+      "license": "MIT",
       "dependencies": {
         "@sanity/uuid": "3.0.2"
       },
@@ -6772,18 +6763,19 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/client": "^6.23.0"
+        "@sanity/client": "^6.27.2"
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "3.69.0",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.69.0.tgz",
-      "integrity": "sha512-f0YtODGyQzz3jKn1704kkdRWg8GOyGHA7Coz88FQMHT9Oqo5bWv5Vk+9bA8ktA3YnIxMXORvDivxtP83lSLpoA==",
+      "version": "3.74.1",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.74.1.tgz",
+      "integrity": "sha512-aPYMgsx8rSJEcn7EYlS4mgS08v957VRhsI4wEiGDvrjwRC1UCkiHPKwxPAvzkbJY1OnWS4+3AJysokx01qKAxQ==",
+      "license": "MIT",
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.69.0",
+        "@sanity/types": "3.74.1",
         "arrify": "^2.0.1",
-        "groq-js": "^1.14.2",
+        "groq-js": "^1.15.0",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
         "lodash": "^4.17.21",
@@ -6825,6 +6817,7 @@
       "version": "0.7.9",
       "resolved": "https://registry.npmjs.org/@sanity/telemetry/-/telemetry-0.7.9.tgz",
       "integrity": "sha512-TBBRK2SUwiNND+ZJPwdWSu8tbEjdIz7UjagmCCBBWcfXtDKXXlWawC/DOEWuI4Q+WcA5OWLDjboxZT4ApWjVbw==",
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
         "rxjs": "^7.8.1",
@@ -6838,9 +6831,10 @@
       }
     },
     "node_modules/@sanity/template-validator": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/template-validator/-/template-validator-2.2.0.tgz",
-      "integrity": "sha512-dUn5shnT5TdK4DL+yp+/zb7iWMZwNi8ERfpqz8PGlCsY6oSc2YZkk40DLgYf2CrhsSE3xUNFgMW7Grnw/kgFhw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@sanity/template-validator/-/template-validator-2.4.0.tgz",
+      "integrity": "sha512-gkQ4hPbfad7CtLrl5ZFReqKbFEBf9ijsyqNJaKny53QTMlyGgwL0JKxiM+bwAiU0uOUT0vSqdzSAxDJNF0BDpg==",
+      "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",
@@ -6856,27 +6850,30 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "3.69.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.69.0.tgz",
-      "integrity": "sha512-LePixWL1co4dxYEtxz6zWYuM7oilAsVhn+FHN9YvBzwg1oBDuMLh6rQWW4ywYghs4J9Xvaq9zv//frXdHUaiTw==",
+      "version": "3.74.1",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.74.1.tgz",
+      "integrity": "sha512-VjV2ZrGXJFYAReoYZ/ea/lMATSqM6utfkYn7mxRm+S6b7lBRaTwQ5uvG2dlbUNjaKGJ2YmrWLh9872hIB94AKw==",
+      "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^6.24.1"
+        "@sanity/client": "^6.27.2"
       },
       "peerDependencies": {
         "@types/react": "18 || 19"
       }
     },
     "node_modules/@sanity/ui": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-2.11.1.tgz",
-      "integrity": "sha512-aO9+dIlwua6QuQfE5O8WF5gb4BUUyunzK2jmT1g/EVovxhkdBOHbmx2bNfw/xNOcSoL0X7ETnKUW4qdR+Hn2TQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-2.12.2.tgz",
+      "integrity": "sha512-HzuZ54nmC7mSdyOUtiu3T31vzVouiQd7780aS6M/SaGGPptYxJ2gwxlrlU6KEaOM+VkjLt6Dk3ewDA7T4sNcbg==",
+      "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.2",
+        "@juggle/resize-observer": "^3.4.0",
         "@sanity/color": "^3.0.6",
         "@sanity/icons": "^3.5.7",
         "csstype": "^3.1.3",
-        "framer-motion": "^11.16.0",
-        "react-compiler-runtime": "19.0.0-beta-55955c9-20241229",
+        "framer-motion": "^12.4.1",
+        "react-compiler-runtime": "19.0.0-beta-714736e-20250131",
         "react-refractor": "^2.2.0",
         "use-effect-event": "^1.0.2"
       },
@@ -6890,13 +6887,23 @@
         "styled-components": "^5.2 || ^6"
       }
     },
+    "node_modules/@sanity/ui/node_modules/react-compiler-runtime": {
+      "version": "19.0.0-beta-714736e-20250131",
+      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.0.0-beta-714736e-20250131.tgz",
+      "integrity": "sha512-RJQqbR2zIobjLZ242MRQlWlyxLDxw0fRxbniImHxSsBqHSf35vK8CsClA37MfO729M3n4jCIawI3BCdBHksOvA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
+      }
+    },
     "node_modules/@sanity/util": {
-      "version": "3.69.0",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.69.0.tgz",
-      "integrity": "sha512-pN6dfM8AF5pxvzHxUwiCamV8WiSx7ZYqv0cWp96seumCj8iiyHOAvzOE4QPlFcu5ymGWveKUB0aCZEmuoUfMpw==",
+      "version": "3.74.1",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.74.1.tgz",
+      "integrity": "sha512-wwRR0r3dB1+O4DFHZfsFD698wqnIcTFLpbUD/oerVvD/Q3pL/ntveomcZFQ8sZancsBg/z4+41D/6mt7x0BQNg==",
+      "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^6.24.1",
-        "@sanity/types": "3.69.0",
+        "@sanity/client": "^6.27.2",
+        "@sanity/types": "3.74.1",
         "get-random-values-esm": "1.0.2",
         "moment": "^2.30.1",
         "rxjs": "^7.8.1"
@@ -6961,6 +6968,24 @@
       "peerDependencies": {
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19"
+      }
+    },
+    "node_modules/@sanity/visual-editing-types": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-1.0.5.tgz",
+      "integrity": "sha512-iRTgMU53P6vv2tGAi/mrGSfZIlMnQ9S2UQB8v2qC/YDxETNpRec3+00mW/pc3IlrPjE7dIOjI6dWHgLG3cSLFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@sanity/client": "^6.27.2",
+        "@sanity/types": "*"
+      },
+      "peerDependenciesMeta": {
+        "@sanity/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/@sec-ant/readable-stream": {
@@ -8719,16 +8744,17 @@
       }
     },
     "node_modules/@xstate/react": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-5.0.1.tgz",
-      "integrity": "sha512-6JK6tcQdAIydu28wnfhY5JJNS8LGRoVZko0CiYaC3405352Mfc5pDPdBAKVFx1OnIJvyj5Hw3/MyQQ2fBTGCcQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-5.0.2.tgz",
+      "integrity": "sha512-x5GOrE0ZYjU2ba986u0CCp7SaPwzElSn1SW0mZ9MuBgsZ+BW7vTLVOvGmURynwojdso8d6nVbK3c2+MRVqGVgA==",
+      "license": "MIT",
       "dependencies": {
         "use-isomorphic-layout-effect": "^1.1.2",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-0",
-        "xstate": "^5.19.1"
+        "xstate": "^5.19.2"
       },
       "peerDependenciesMeta": {
         "xstate": {
@@ -9242,6 +9268,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -9449,7 +9476,8 @@
     "node_modules/before-after-hook": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
@@ -9577,6 +9605,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "license": "MIT",
       "dependencies": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -9585,7 +9614,8 @@
     "node_modules/buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "license": "MIT"
     },
     "node_modules/buffer-crc32": {
       "version": "1.0.0",
@@ -9598,7 +9628,8 @@
     "node_modules/buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "license": "MIT"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -9608,7 +9639,8 @@
     "node_modules/builtins": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-      "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ=="
+      "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
+      "license": "MIT"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -10129,6 +10161,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
       "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "license": "MIT",
       "dependencies": {
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
@@ -10282,9 +10315,10 @@
       }
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
-      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -10941,6 +10975,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
       "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+      "license": "MIT",
       "dependencies": {
         "decompress-tar": "^4.0.0",
         "decompress-tarbz2": "^4.0.0",
@@ -10973,6 +11008,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+      "license": "MIT",
       "dependencies": {
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0",
@@ -10986,6 +11022,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
       "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+      "license": "MIT",
       "dependencies": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -10995,6 +11032,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11002,12 +11040,14 @@
     "node_modules/decompress-tar/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/decompress-tar/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -11021,12 +11061,14 @@
     "node_modules/decompress-tar/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/decompress-tar/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -11035,6 +11077,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "license": "MIT",
       "dependencies": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
@@ -11052,6 +11095,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+      "license": "MIT",
       "dependencies": {
         "decompress-tar": "^4.1.0",
         "file-type": "^6.1.0",
@@ -11067,6 +11111,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
       "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -11075,6 +11120,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11083,6 +11129,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+      "license": "MIT",
       "dependencies": {
         "decompress-tar": "^4.1.1",
         "file-type": "^5.2.0",
@@ -11096,6 +11143,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11104,6 +11152,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
+      "license": "MIT",
       "dependencies": {
         "file-type": "^3.8.0",
         "get-stream": "^2.2.0",
@@ -11118,6 +11167,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
       "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11126,6 +11176,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
       "integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
+      "license": "MIT",
       "dependencies": {
         "object-assign": "^4.0.1",
         "pinkie-promise": "^2.0.0"
@@ -11138,6 +11189,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "license": "MIT",
       "dependencies": {
         "pify": "^3.0.0"
       },
@@ -11149,6 +11201,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -11257,7 +11310,8 @@
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "license": "ISC"
     },
     "node_modules/detect-indent": {
       "version": "7.0.1",
@@ -11309,6 +11363,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
       "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
+      "license": "MIT",
       "bin": {
         "direction": "cli.js"
       },
@@ -12650,6 +12705,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -12718,6 +12774,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
       "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -12758,6 +12815,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
       "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "license": "MIT",
       "dependencies": {
         "commondir": "^1.0.1",
         "make-dir": "^2.0.0",
@@ -12771,6 +12829,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^3.0.0"
       },
@@ -12782,6 +12841,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -12794,6 +12854,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -12808,6 +12869,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.0.0"
       },
@@ -12819,6 +12881,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -12827,6 +12890,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "license": "MIT",
       "dependencies": {
         "find-up": "^3.0.0"
       },
@@ -13002,12 +13066,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "11.16.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.16.1.tgz",
-      "integrity": "sha512-xsjhEUSWHn39g334PpBTH+QissgEJVJkpRGS/4QUyMSmoJSNxA+7FTuq61s+OXPMS4muu5k9Y6r7GpcNKhd1xA==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.4.1.tgz",
+      "integrity": "sha512-5Ijbea3topSZjadQ0hgc/TcWj2ldMZmNREM7RvAhvsThYOA1HHOA8TT1yKvMu1YXP3jWaFwoZ6Vo9Nw+DUZrzA==",
+      "license": "MIT",
       "dependencies": {
-        "motion-dom": "^11.16.1",
-        "motion-utils": "^11.16.0",
+        "motion-dom": "^12.0.0",
+        "motion-utils": "^12.0.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -13254,14 +13319,15 @@
       }
     },
     "node_modules/get-it": {
-      "version": "8.6.5",
-      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.6.5.tgz",
-      "integrity": "sha512-o1hjPwrb/icm3WJbCweTSq8mKuDfJlqwbFauI+Pdgid99at/BFaBXFBJZE+uqvHyOVARE4z680S44vrDm8SsCw==",
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.6.7.tgz",
+      "integrity": "sha512-AMEotvykAlcEPTPmYeZPqr9w3K53Ni8z1tplo1mwNS8T4i/gr5T7mSfvaLhhIQhF+0thIH901kLdDA5d5bvDGA==",
+      "license": "MIT",
       "dependencies": {
         "@types/follow-redirects": "^1.14.4",
         "@types/progress-stream": "^2.0.5",
         "decompress-response": "^7.0.0",
-        "follow-redirects": "^1.15.6",
+        "follow-redirects": "^1.15.9",
         "is-retry-allowed": "^2.2.0",
         "progress-stream": "^2.0.0",
         "tunnel-agent": "^0.6.0"
@@ -13703,17 +13769,19 @@
       "dev": true
     },
     "node_modules/groq": {
-      "version": "3.69.0",
-      "resolved": "https://registry.npmjs.org/groq/-/groq-3.69.0.tgz",
-      "integrity": "sha512-z/UnX+4op+xM1X4BStvydrHg484CbI/VoZcfhGDlIZA0xj5DeKQsPO3MXyWqLvuMcU2nnDlnpJZ1ccI1XAlO8Q==",
+      "version": "3.74.1",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-3.74.1.tgz",
+      "integrity": "sha512-nQq2qlCTFNhkBZJ4tHY1tXQHEZDlqg/iFOtQIF5PEJNqrTG7/GQrHKwKlTjfcbq+qnJys2t45qVn10uLZAteZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/groq-js": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-1.14.2.tgz",
-      "integrity": "sha512-1CtOqgATOhmB6jRKL6zvojb2Vt8aP2y6m/7ZN4JlpFhyB/d8WRW3/kZgapIUHys6/Vrkk1oTbjjDbxNL8QxHSQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-1.15.0.tgz",
+      "integrity": "sha512-PB0phOsvoYq6V5G5K5nOUDhzHH6NaqlzSaUmjBNS487kU/CJ0m2xIuvbnZM5nz1oC1jfDpCW3IXh3GKpMpU5Pw==",
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -13941,7 +14009,8 @@
     "node_modules/hotscript": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/hotscript/-/hotscript-1.0.13.tgz",
-      "integrity": "sha512-C++tTF1GqkGYecL+2S1wJTfoH6APGAsbb7PAWQ3iVIwgG/EFseAfEVOKFgAFq4yK3+6j1EjUD4UQ9dRJHX/sSQ=="
+      "integrity": "sha512-C++tTF1GqkGYecL+2S1wJTfoH6APGAsbb7PAWQ3iVIwgG/EFseAfEVOKFgAFq4yK3+6j1EjUD4UQ9dRJHX/sSQ==",
+      "license": "ISC"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -13998,7 +14067,8 @@
     "node_modules/humanize-list": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/humanize-list/-/humanize-list-1.0.1.tgz",
-      "integrity": "sha512-4+p3fCRF21oUqxhK0yZ6yaSP/H5/wZumc7q1fH99RkW7Q13aAxDeP78BKjoR+6y+kaHqKF/JWuQhsNuuI2NKtA=="
+      "integrity": "sha512-4+p3fCRF21oUqxhK0yZ6yaSP/H5/wZumc7q1fH99RkW7Q13aAxDeP78BKjoR+6y+kaHqKF/JWuQhsNuuI2NKtA==",
+      "license": "MIT"
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -14637,7 +14707,8 @@
     "node_modules/is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-      "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ=="
+      "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -14695,6 +14766,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -14939,6 +15011,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15070,7 +15143,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -15375,6 +15448,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -16096,6 +16170,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "license": "MIT",
       "dependencies": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
@@ -16108,6 +16183,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -16116,6 +16192,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -16214,6 +16291,7 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/mendoza/-/mendoza-3.0.8.tgz",
       "integrity": "sha512-iwxgEpSOx9BDLJMD0JAzNicqo9xdrvzt6w/aVwBKMndlA6z/DH41+o60H2uHB0vCR1Xr37UOgu9xFWJHvYsuKw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.18"
       }
@@ -16539,14 +16617,6 @@
         "ufo": "^1.5.4"
       }
     },
-    "node_modules/mnemonist": {
-      "version": "0.39.8",
-      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.8.tgz",
-      "integrity": "sha512-vyWo2K3fjrUw8YeeZ1zF0fy6Mu59RHokURlld8ymdUPjMlD9EC9ov1/YPqTgqRvUN9nTr3Gqfz29LYAmu0PHPQ==",
-      "dependencies": {
-        "obliterator": "^2.0.1"
-      }
-    },
     "node_modules/module-alias": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
@@ -16561,17 +16631,19 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "11.16.1",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.16.1.tgz",
-      "integrity": "sha512-XVNf3iCfZn9OHPZYJQy5YXXLn0NuPNvtT3YCat89oAnr4D88Cr52KqFgKa8dWElBK8uIoQhpJMJEG+dyniYycQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.0.0.tgz",
+      "integrity": "sha512-CvYd15OeIR6kHgMdonCc1ihsaUG4MYh/wrkz8gZ3hBX/uamyZCXN9S9qJoYF03GqfTt7thTV/dxnHYX4+55vDg==",
+      "license": "MIT",
       "dependencies": {
-        "motion-utils": "^11.16.0"
+        "motion-utils": "^12.0.0"
       }
     },
     "node_modules/motion-utils": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.16.0.tgz",
-      "integrity": "sha512-ngdWPjg31rD4WGXFi0eZ00DQQqKKu04QExyv/ymlC+3k+WIgYVFbt6gS5JsFPbJODTF/r8XiE/X+SsoT9c0ocw=="
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.0.0.tgz",
+      "integrity": "sha512-MNFiBKbbqnmvOjkPyOKgHUp3Q6oiokLkI1bEwm5QA28cxMZrv0CbbBGDNmhF6DIXsi1pCQBSs0dX8xjeER1tmA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -19951,15 +20023,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/obliterator": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
-      "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw=="
-    },
     "node_modules/observable-callback": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/observable-callback/-/observable-callback-1.0.3.tgz",
       "integrity": "sha512-VlS275UyPnwdMtzxDgr/lCiOUyq9uXNll3vdwzDcJ6PB/LuO7gLmxAQopcCA3JoFwwujBwyA7/tP5TXZwWSXew==",
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -20546,7 +20614,8 @@
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -20627,7 +20696,8 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -20666,6 +20736,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20674,6 +20745,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20682,6 +20754,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "license": "MIT",
       "dependencies": {
         "pinkie": "^2.0.0"
       },
@@ -20693,6 +20766,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -20781,6 +20855,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
       "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+      "license": "MIT",
       "dependencies": {
         "find-up": "^5.0.0"
       },
@@ -20792,6 +20867,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -20807,6 +20883,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -20821,6 +20898,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -20835,6 +20913,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -20849,6 +20928,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -20857,6 +20937,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -20978,9 +21059,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
+      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -20995,8 +21076,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -21556,17 +21638,27 @@
       }
     },
     "node_modules/react-rx": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-4.1.12.tgz",
-      "integrity": "sha512-rX8WaVq+YkW9AcfKrEIXg8X15dR9pLHU7JZh4K1Ffc2k8zM4YuR7xh0Fi5EkranqcTAFGKoN2Z+q5QY8k+lHxA==",
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-4.1.18.tgz",
+      "integrity": "sha512-q3QiZi/cmOA2eUlK9UKba1qfziw11D3mwKtVTw/J85tbSQjvM2lK8JJ1HG2+4gJ43zZAVTd9lrf6NCtAKpK9xQ==",
+      "license": "MIT",
       "dependencies": {
         "observable-callback": "^1.0.3",
-        "react-compiler-runtime": "19.0.0-beta-55955c9-20241229",
+        "react-compiler-runtime": "19.0.0-beta-714736e-20250131",
         "use-effect-event": "^1.0.2"
       },
       "peerDependencies": {
         "react": "^18.3 || >=19.0.0-0",
         "rxjs": "^7"
+      }
+    },
+    "node_modules/react-rx/node_modules/react-compiler-runtime": {
+      "version": "19.0.0-beta-714736e-20250131",
+      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.0.0-beta-714736e-20250131.tgz",
+      "integrity": "sha512-RJQqbR2zIobjLZ242MRQlWlyxLDxw0fRxbniImHxSsBqHSf35vK8CsClA37MfO729M3n4jCIawI3BCdBHksOvA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
       }
     },
     "node_modules/react-select": {
@@ -22294,6 +22386,18 @@
         "rxjs": "7.x"
       }
     },
+    "node_modules/rxjs-mergemap-array": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rxjs-mergemap-array/-/rxjs-mergemap-array-0.1.0.tgz",
+      "integrity": "sha512-19fXxPXN4X8LPWu7fg/nyX+nr0G97qSNXhEvF32cdgWuoyUVQ4MrFr+UL4HGip6iO5kbZOL4puAjPeQ/D5qSlA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "rxjs": "7.x"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -22368,42 +22472,46 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanity": {
-      "version": "3.69.0",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.69.0.tgz",
-      "integrity": "sha512-aAjOwVlv+dAyp0Ivbs4RE0WAJSrqv5Fr2YReMNl74zTy3HiD2k6XI3DguYOtOWwp3R0i3vOp8O31FVCa/ycjug==",
+      "version": "3.74.1",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.74.1.tgz",
+      "integrity": "sha512-ZHM4LTMSJHq2mgkg3+SUOaE45Yq80HEj7lcxQ6pnLxXnfWwc1YfIWfFZqzO4RmavnzlKJcCVN7IJ7gelaJbW/g==",
+      "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.0.5",
         "@dnd-kit/modifiers": "^6.0.0",
         "@dnd-kit/sortable": "^7.0.1",
         "@dnd-kit/utilities": "^3.2.0",
         "@juggle/resize-observer": "^3.3.1",
-        "@portabletext/editor": "^1.20.0",
+        "@portabletext/block-tools": "^1.1.4",
+        "@portabletext/editor": "^1.30.3",
         "@portabletext/react": "^3.0.0",
+        "@portabletext/toolkit": "^2.0.16",
         "@rexxars/react-json-inspector": "^9.0.1",
         "@sanity/asset-utils": "^2.0.6",
         "@sanity/bifur-client": "^0.4.1",
-        "@sanity/block-tools": "3.69.0",
-        "@sanity/cli": "3.69.0",
-        "@sanity/client": "^6.24.1",
+        "@sanity/cli": "3.74.1",
+        "@sanity/client": "^6.27.2",
         "@sanity/color": "^3.0.0",
-        "@sanity/diff": "3.69.0",
+        "@sanity/comlink": "^3.0.1",
+        "@sanity/diff": "3.74.1",
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/eventsource": "^5.0.0",
         "@sanity/export": "^3.42.2",
         "@sanity/icons": "^3.5.7",
         "@sanity/image-url": "^1.0.2",
         "@sanity/import": "^3.37.9",
-        "@sanity/insert-menu": "1.0.18",
-        "@sanity/logos": "^2.1.4",
-        "@sanity/migrate": "3.69.0",
-        "@sanity/mutator": "3.69.0",
-        "@sanity/presentation": "1.20.1",
-        "@sanity/schema": "3.69.0",
+        "@sanity/insert-menu": "1.0.20",
+        "@sanity/logos": "^2.1.13",
+        "@sanity/migrate": "3.74.1",
+        "@sanity/mutator": "3.74.1",
+        "@sanity/presentation-comlink": "^1.0.4",
+        "@sanity/preview-url-secret": "^2.1.4",
+        "@sanity/schema": "3.74.1",
         "@sanity/telemetry": "^0.7.7",
-        "@sanity/types": "3.69.0",
-        "@sanity/ui": "^2.11.1",
-        "@sanity/util": "3.69.0",
-        "@sanity/uuid": "^3.0.1",
+        "@sanity/types": "3.74.1",
+        "@sanity/ui": "^2.11.8",
+        "@sanity/util": "3.74.1",
+        "@sanity/uuid": "^3.0.2",
         "@sentry/react": "^8.33.0",
         "@tanstack/react-table": "^8.16.0",
         "@tanstack/react-virtual": "^3.11.2",
@@ -22429,11 +22537,12 @@
         "esbuild-register": "^3.5.0",
         "execa": "^2.0.0",
         "exif-component": "^1.0.1",
+        "fast-deep-equal": "3.1.3",
         "form-data": "^4.0.0",
-        "framer-motion": "^11.15.0",
-        "get-it": "^8.6.5",
+        "framer-motion": "^12.0.0",
+        "get-it": "^8.6.7",
         "get-random-values-esm": "1.0.2",
-        "groq-js": "^1.14.2",
+        "groq-js": "^1.15.0",
         "history": "^5.3.0",
         "i18next": "^23.2.7",
         "import-fresh": "^3.3.0",
@@ -22455,19 +22564,20 @@
         "oneline": "^1.0.3",
         "open": "^8.4.0",
         "p-map": "^7.0.0",
+        "path-to-regexp": "^6.3.0",
         "pirates": "^4.0.0",
         "pluralize-esm": "^9.0.2",
         "polished": "^4.2.2",
         "pretty-ms": "^7.0.1",
         "quick-lru": "^5.1.1",
         "raf": "^3.4.1",
-        "react-compiler-runtime": "19.0.0-beta-55955c9-20241229",
+        "react-compiler-runtime": "19.0.0-beta-714736e-20250131",
         "react-fast-compare": "^3.2.0",
         "react-focus-lock": "^2.13.5",
         "react-i18next": "14.0.2",
         "react-is": "^18.2.0",
         "react-refractor": "^2.1.6",
-        "react-rx": "^4.1.12",
+        "react-rx": "^4.1.18",
         "read-pkg-up": "^7.0.1",
         "refractor": "^3.6.0",
         "resolve-from": "^5.0.0",
@@ -22475,18 +22585,22 @@
         "rimraf": "^5.0.10",
         "rxjs": "^7.8.0",
         "rxjs-exhaustmap-with-trailing": "^2.1.1",
+        "rxjs-mergemap-array": "^0.1.0",
         "sanity-diff-patch": "^4.0.0",
         "scroll-into-view-if-needed": "^3.0.3",
         "semver": "^7.3.5",
         "shallow-equals": "^1.0.0",
         "speakingurl": "^14.0.1",
+        "suspend-react": "0.1.3",
         "tar-fs": "^2.1.1",
         "tar-stream": "^3.1.7",
         "use-device-pixel-ratio": "^1.1.0",
         "use-effect-event": "^1.0.2",
         "use-hot-module-reload": "^2.0.0",
         "use-sync-external-store": "^1.2.0",
-        "vite": "^5.4.11",
+        "uuid": "^11.0.5",
+        "valibot": "0.31.1",
+        "vite": "^6.0.11",
         "yargs": "^17.3.0"
       },
       "bin": {
@@ -23060,6 +23174,72 @@
         "node": ">=12"
       }
     },
+    "node_modules/sanity/node_modules/@portabletext/block-tools": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-1.1.6.tgz",
+      "integrity": "sha512-u+eJpY/60vzKGDxus1UDOdZ7fRR42qQcFJcJaMHo0yyeRvp2Pz2/e5AEDhO45XDd2M2FSM8eSFqSGRiGgS3NhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-random-values-esm": "1.0.2",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@sanity/types": "^3.74.1",
+        "@types/react": "18 || 19"
+      }
+    },
+    "node_modules/sanity/node_modules/@portabletext/editor": {
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-1.31.0.tgz",
+      "integrity": "sha512-354MCNmqkrDAktcg4+h42IKDP2mLu/q48Vv7MvvNEQIwdSpqxkGzg8RsEw2IlkjXB4heJvpQKGi8e6Q9JdfPZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/block-tools": "1.1.6",
+        "@portabletext/patches": "1.1.2",
+        "@portabletext/to-html": "^2.0.14",
+        "@xstate/react": "^5.0.2",
+        "debug": "^4.4.0",
+        "get-random-values-esm": "^1.0.2",
+        "lodash": "^4.17.21",
+        "lodash.startcase": "^4.4.0",
+        "react-compiler-runtime": "19.0.0-beta-714736e-20250131",
+        "slate": "0.112.0",
+        "slate-dom": "^0.112.2",
+        "slate-react": "0.112.1",
+        "use-effect-event": "^1.0.2",
+        "xstate": "^5.19.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@sanity/schema": "^3.74.1",
+        "@sanity/types": "^3.74.1",
+        "react": "^16.9 || ^17 || ^18 || ^19",
+        "rxjs": "^7.8.1"
+      }
+    },
+    "node_modules/sanity/node_modules/@portabletext/editor/node_modules/slate-react": {
+      "version": "0.112.1",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.112.1.tgz",
+      "integrity": "sha512-V9b+waxPweXqAkSQmKQ1afG4Me6nVQACPpxQtHPIX02N7MXa5f5WilYv+bKt7vKKw+IZC2F0Gjzhv5BekVgP/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "slate": ">=0.99.0",
+        "slate-dom": ">=0.110.2"
+      }
+    },
     "node_modules/sanity/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -23248,6 +23428,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/sanity/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sanity/node_modules/log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -23357,6 +23546,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/sanity/node_modules/react-compiler-runtime": {
+      "version": "19.0.0-beta-714736e-20250131",
+      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.0.0-beta-714736e-20250131.tgz",
+      "integrity": "sha512-RJQqbR2zIobjLZ242MRQlWlyxLDxw0fRxbniImHxSsBqHSf35vK8CsClA37MfO729M3n4jCIawI3BCdBHksOvA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
+      }
+    },
     "node_modules/sanity/node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -23393,6 +23591,491 @@
         "node": ">=8"
       }
     },
+    "node_modules/sanity/node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
+      "license": "MIT"
+    },
+    "node_modules/sanity/node_modules/vite": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.0.tgz",
+      "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.24.2",
+        "postcss": "^8.5.1",
+        "rollup": "^4.30.1"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sanity/node_modules/vite/node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -23416,6 +24099,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
       "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "license": "MIT",
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
@@ -23424,6 +24108,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
       "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
+      "license": "MIT",
       "dependencies": {
         "commander": "^2.8.1"
       },
@@ -23435,7 +24120,8 @@
     "node_modules/seek-bzip/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/semantic-release": {
       "version": "23.1.1",
@@ -23866,6 +24552,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.2"
       },
@@ -24135,6 +24822,7 @@
       "version": "0.112.0",
       "resolved": "https://registry.npmjs.org/slate/-/slate-0.112.0.tgz",
       "integrity": "sha512-PRnfFgDA3tSop4OH47zu4M1R4Uuhm/AmASu29Qp7sGghVFb713kPBKEnSf1op7Lx/nCHkRlCa3ThfHtCBy+5Yw==",
+      "license": "MIT",
       "dependencies": {
         "immer": "^10.0.3",
         "is-plain-object": "^5.0.0",
@@ -24142,9 +24830,10 @@
       }
     },
     "node_modules/slate-dom": {
-      "version": "0.111.0",
-      "resolved": "https://registry.npmjs.org/slate-dom/-/slate-dom-0.111.0.tgz",
-      "integrity": "sha512-VjeBh2xIRvP6ToEhrO1TPahc5fPezxbeSUhsRTppBPtHfidEdyp/MTI9TjUrZnlznJiVZ7QKrORXilFq8hsbtQ==",
+      "version": "0.112.2",
+      "resolved": "https://registry.npmjs.org/slate-dom/-/slate-dom-0.112.2.tgz",
+      "integrity": "sha512-cozITMlpcBxrov854reM6+TooiHiqpfM/nZPrnjpN1wSiDsAQmYbWUyftC+jlwcpFj80vywfDHzlG6hXIc5h6A==",
+      "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
         "direction": "^1.0.4",
@@ -24162,6 +24851,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24169,12 +24859,14 @@
     "node_modules/slate-dom/node_modules/tiny-invariant": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
+      "license": "MIT"
     },
     "node_modules/slate/node_modules/immer": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
       "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -24184,6 +24876,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24672,6 +25365,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+      "license": "MIT",
       "dependencies": {
         "is-natural-number": "^4.0.1"
       }
@@ -25197,7 +25891,8 @@
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -25272,7 +25967,8 @@
     "node_modules/to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -25385,6 +26081,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
       "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "license": "MIT",
       "dependencies": {
         "json5": "^2.2.2",
         "minimist": "^1.2.6",
@@ -25403,6 +26100,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
@@ -25538,6 +26236,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/typeid-js/-/typeid-js-0.3.0.tgz",
       "integrity": "sha512-A1EmvIWG6xwYRfHuYUjPltHqteZ1EiDG+HOmbIYXeHUVztmnGrPIfU9KIK1QC30x59ko0r4JsMlwzsALCyiB3Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "uuidv7": "^0.4.4"
       }
@@ -25594,6 +26293,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
       "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -25606,9 +26306,10 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -25722,7 +26423,8 @@
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -25869,6 +26571,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
       "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -25890,13 +26593,14 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.4.tgz",
-      "integrity": "sha512-IzL6VtTTYcAhA/oghbFJ1Dkmqev+FpQWnCBaKq/gUluLxliWvO8DPFWfIviRmYbtaavtSQe4WBL++rFjdcGWEg==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
@@ -25905,9 +26609,16 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/uuidv7/-/uuidv7-0.4.4.tgz",
       "integrity": "sha512-jjRGChg03uGp9f6wQYSO8qXkweJwRbA5WRuEQE8xLIiehIzIIi23qZSzsyvZPCPoFqkeLtZuz7Plt1LGukAInA==",
+      "license": "Apache-2.0",
       "bin": {
         "uuidv7": "cli.js"
       }
+    },
+    "node_modules/valibot": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.31.1.tgz",
+      "integrity": "sha512-2YYIhPrnVSz/gfT2/iXVTrSj92HwchCt9Cga/6hX4B26iCz9zkIsGTS0HjDYTZfTi1Un0X6aRvhBi1cfqs/i0Q==",
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -26018,6 +26729,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26033,6 +26745,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26048,6 +26761,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26063,6 +26777,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26078,6 +26793,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26093,6 +26809,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26108,6 +26825,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26123,6 +26841,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26138,6 +26857,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26153,6 +26873,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26168,6 +26889,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26183,6 +26905,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26198,6 +26921,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26213,6 +26937,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26228,6 +26953,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26243,6 +26969,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26258,6 +26985,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26273,6 +27001,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26288,6 +27017,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26303,6 +27033,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26318,6 +27049,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26333,6 +27065,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26348,6 +27081,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26921,9 +27655,10 @@
       }
     },
     "node_modules/xstate": {
-      "version": "5.19.1",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.19.1.tgz",
-      "integrity": "sha512-vFt3q9EBnO/qTTf9AG/5GosGwdDEftw5VOd3ytfSwUQRvkj6oJkxeBQaCqJUANjHrkK341jMkEZP0zeqrx2tww==",
+      "version": "5.19.2",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.19.2.tgz",
+      "integrity": "sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"
@@ -27166,6 +27901,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -27175,6 +27911,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -27275,7 +28012,7 @@
     },
     "plugin": {
       "name": "@sanity/assist",
-      "version": "3.0.9",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@sanity/icons": "^3.5.2",
@@ -27310,7 +28047,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rimraf": "^5.0.5",
-        "sanity": "^3.69.0",
+        "sanity": "^3.74.1",
         "semantic-release": "^23.0.8",
         "styled-components": "^6.1.8",
         "typescript": "^5.7.2",
@@ -27403,7 +28140,7 @@
         "react-animate-height": "^3.2.3",
         "react-dom": "^18.2.0",
         "react-is": "^18.2.0",
-        "sanity": "^3.69.0",
+        "sanity": "^3.74.1",
         "sanity-plugin-internationalized-array": "^2.0.0",
         "sanity-plugin-media": "^2.2.5",
         "styled-components": "^6.1.8"

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -81,7 +81,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^5.0.5",
-    "sanity": "^3.69.0",
+    "sanity": "^3.74.1",
     "semantic-release": "^23.0.8",
     "styled-components": "^6.1.8",
     "typescript": "^5.7.2",

--- a/plugin/src/components/ImageContext.tsx
+++ b/plugin/src/components/ImageContext.tsx
@@ -18,11 +18,7 @@ export const ImageContext = createContext<ImageContextValue>({})
 export function ImageContextProvider(props: InputProps) {
   const {schemaType, path, value, readOnly} = props
   const assetRef = (value as any)?.asset?._ref
-  const {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore this is a valid option available in `corel` - Remove after corel is merged to next
-    selectedReleaseId,
-  } = useDocumentPane()
+  const {selectedReleaseId} = useDocumentPane()
   const [assetRefState, setAssetRefState] = useState<string | undefined>(assetRef)
 
   const {assistableDocumentId, documentSchemaType} = useAssistDocumentContext()
@@ -33,9 +29,7 @@ export function ImageContextProvider(props: InputProps) {
   const {isSyncing} = useSyncState(
     getPublishedId(assistableDocumentId),
     documentSchemaType.name,
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore this is a valid option available in `corel` - Remove after corel is merged to next
-    selectedReleaseId ? {version: selectedReleaseId} : undefined,
+    selectedReleaseId,
   )
 
   const router = usePaneRouter()

--- a/studio/package.json
+++ b/studio/package.json
@@ -35,7 +35,7 @@
     "react-animate-height": "^3.2.3",
     "react-dom": "^18.2.0",
     "react-is": "^18.2.0",
-    "sanity": "^3.69.0",
+    "sanity": "^3.74.1",
     "sanity-plugin-internationalized-array": "^2.0.0",
     "sanity-plugin-media": "^2.2.5",
     "styled-components": "^6.1.8"


### PR DESCRIPTION
The stable `sanity` package has a new signature for `useSyncState` that no longer supports an object being provided as the `version` argument. This argument must satisfy `string | undefined`.

This causes `ImageContextProvider` to throw an error when rendered in a Studio with a release selected, because the version id incorrectly gets stringified to `[object Object]` when used in a Sanity HTTP API request. The HTTP API fails with a `400` response code in this scenario.

Note: we should make further changes here to use `PerspectiveProvider`, but I wanted to fix the immediate issue.