### PR TITLE
feat: can now set maxPathDepth for field translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
       "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
-      "license": "MIT",
       "dependencies": {
         "@actions/exec": "^1.1.1",
         "@actions/http-client": "^2.0.1"
@@ -37,7 +36,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
       "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
-      "license": "MIT",
       "dependencies": {
         "@actions/io": "^1.0.1"
       }
@@ -46,7 +44,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.0.tgz",
       "integrity": "sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==",
-      "license": "MIT",
       "dependencies": {
         "@actions/http-client": "^2.2.0",
         "@octokit/core": "^5.0.1",
@@ -54,11 +51,124 @@
         "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
       }
     },
+    "node_modules/@actions/github/node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+    },
+    "node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@actions/github/node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+    },
+    "node_modules/@actions/github/node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+    },
     "node_modules/@actions/http-client": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
       "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
-      "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
@@ -67,8 +177,7 @@
     "node_modules/@actions/io": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
-      "license": "MIT"
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -1620,7 +1729,6 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.25.9.tgz",
       "integrity": "sha512-8D43jXtGsYmEeDvm4MWHYUpWf8iiXgWYx3fW7E7Wb7Oe6FWqJPl5K6TuFW0dOwNZzEE5rjlaSJYH9JjrUKJszA==",
-      "license": "MIT",
       "dependencies": {
         "clone-deep": "^4.0.1",
         "find-cache-dir": "^2.0.0",
@@ -2788,7 +2896,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
       "engines": {
         "node": ">=14"
       }
@@ -3122,6 +3229,7 @@
       "version": "7.49.0",
       "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.49.0.tgz",
       "integrity": "sha512-X5b462k0/yl8qWdGx3siq5vyI8fTDU9fRnwqTMlGHqFhLxpASmLWA2EU6nft+ZG8cQM2HRZlr4HSo62UqiAnug==",
+      "dev": true,
       "dependencies": {
         "@microsoft/api-extractor-model": "7.30.1",
         "@microsoft/tsdoc": "~0.15.1",
@@ -3155,6 +3263,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3166,6 +3275,7 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
       "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3177,6 +3287,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3190,7 +3301,8 @@
     "node_modules/@microsoft/api-extractor/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@microsoft/tsdoc": {
       "version": "0.15.1",
@@ -3287,99 +3399,79 @@
       }
     },
     "node_modules/@octokit/auth-token": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
-      "license": "MIT",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
+      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@octokit/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
-      "license": "MIT",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.4.tgz",
+      "integrity": "sha512-lAS9k7d6I0MPN+gb9bKDt7X8SdxknYqAMh44S5L+lNqIN2NuV8nvv3g8rPp7MuRxcOpxpUIATWprO0C34a8Qmg==",
       "dependencies": {
-        "@octokit/auth-token": "^4.0.0",
-        "@octokit/graphql": "^7.1.0",
-        "@octokit/request": "^8.3.1",
-        "@octokit/request-error": "^5.1.0",
-        "@octokit/types": "^13.0.0",
-        "before-after-hook": "^2.2.0",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.1.2",
+        "@octokit/request": "^9.2.1",
+        "@octokit/request-error": "^6.1.7",
+        "@octokit/types": "^13.6.2",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
-      "integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
-      "license": "MIT",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.3.tgz",
+      "integrity": "sha512-nBRBMpKPhQUxCsQQeW+rCJ/OPSMcj3g0nfHn01zGYZXuNDvvXudF/TYY6APj5THlurerpFN4a/dQAIAaM6BYhA==",
       "dependencies": {
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/types": "^13.6.2",
+        "universal-user-agent": "^7.0.2"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
-      "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
-      "license": "MIT",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.1.tgz",
+      "integrity": "sha512-n57hXtOoHrhwTWdvhVkdJHdhTv0JstjDbDRhJfwIRNfFqmSo1DaK/mD2syoNUoLCyqSjBpGAKOG0BuwF392slw==",
       "dependencies": {
-        "@octokit/request": "^8.3.0",
-        "@octokit/types": "^13.0.0",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/request": "^9.2.2",
+        "@octokit/types": "^13.8.0",
+        "universal-user-agent": "^7.0.0"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg=="
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.1.tgz",
-      "integrity": "sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==",
-      "license": "MIT",
+      "version": "11.4.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.3.tgz",
+      "integrity": "sha512-tBXaAbXkqVJlRoA/zQVe9mUdb8rScmivqtpv3ovsC5xhje/a+NOCivs7eUhWBwCApJVsR4G5HMeaLbq7PxqZGA==",
+      "dev": true,
       "dependencies": {
-        "@octokit/types": "^12.6.0"
+        "@octokit/types": "^13.7.0"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": "5"
-      }
-    },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^20.0.0"
+        "@octokit/core": ">=6"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
-      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
-      "license": "MIT",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.0.tgz",
+      "integrity": "sha512-INw5rGXWlbv/p/VvQL63dhlXr38qYTHkQ5bANi9xofrF9OraqmjHsIGyenmjmul1JVRHpUlw5heFOj1UZLEolA==",
       "dependencies": {
         "@octokit/types": "^12.6.0"
       },
@@ -3387,59 +3479,54 @@
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": "5"
+        "@octokit/core": ">=5"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-      "license": "MIT"
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
       "version": "12.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
       "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
       }
     },
     "node_modules/@octokit/request": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
-      "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
-      "license": "MIT",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.2.tgz",
+      "integrity": "sha512-dZl0ZHx6gOQGcffgm1/Sf6JfEpmh34v3Af2Uci02vzUYz6qEN6zepoRtmybWXIGXFIK8K9ylE3b+duCWqhArtg==",
       "dependencies": {
-        "@octokit/endpoint": "^9.0.1",
-        "@octokit/request-error": "^5.1.0",
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/endpoint": "^10.1.3",
+        "@octokit/request-error": "^6.1.7",
+        "@octokit/types": "^13.6.2",
+        "fast-content-type-parse": "^2.0.0",
+        "universal-user-agent": "^7.0.2"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
-      "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
-      "license": "MIT",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.7.tgz",
+      "integrity": "sha512-69NIppAwaauwZv6aOzb+VVLwt+0havz9GT5YplkeJv7fG7a40qpLt/yZKyiDxAhgz0EtgNdNcb96Z0u+Zyuy2g==",
       "dependencies": {
-        "@octokit/types": "^13.1.0",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
+        "@octokit/types": "^13.6.2"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@octokit/types": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.2.tgz",
-      "integrity": "sha512-WpbZfZUcZU77DrSW4wbsSgTPfKcp286q3ItaIgvSbBpZJlu6mnYXAkjZz6LVZPXkEvLIM8McanyZejKTYUHipA==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
       "dependencies": {
-        "@octokit/openapi-types": "^22.2.0"
+        "@octokit/openapi-types": "^23.0.1"
       }
     },
     "node_modules/@optimize-lodash/rollup-plugin": {
@@ -3528,10 +3615,9 @@
       }
     },
     "node_modules/@portabletext/patches": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@portabletext/patches/-/patches-1.1.2.tgz",
-      "integrity": "sha512-ENGxLD+AJc2Uq2GfDCNmeU/9dT50VYBMX5zKYyPVw2/OYDEpLYDlEZBjh0v0RqEuE2ecUu+eBaHf4PE6C0CoQQ==",
-      "license": "MIT",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@portabletext/patches/-/patches-1.1.3.tgz",
+      "integrity": "sha512-9olhOppydPR/UoMVf9w3SxHR3l9UJ66GoI/hnG34ESf6ccewI6cgLMXdcn9MPiFIve46hFMO/hP7g7exmN6RSg==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.2.0",
         "lodash": "^4.17.21"
@@ -3556,7 +3642,6 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@portabletext/to-html/-/to-html-2.0.14.tgz",
       "integrity": "sha512-wW2et59PoOT/mc56C4U3z+DKAx1yjieN/gp2q9szTfTwusMpb6mclR9+EPIfGrcQWdwGn6PEN7nxVFXnqlZ/0A==",
-      "license": "MIT",
       "dependencies": {
         "@portabletext/toolkit": "^2.0.17",
         "@portabletext/types": "^2.0.13"
@@ -4186,17 +4271,16 @@
       "integrity": "sha512-so+/UtCge8t1jq509hH0otbbptRz0zM/Aa0dh5MhMD7HGT6n2igWIL2VWH/9QR9e77Jn3dJsjz23mW1WCxT+sg=="
     },
     "node_modules/@sanity/cli": {
-      "version": "3.74.1",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.74.1.tgz",
-      "integrity": "sha512-Sny5RzUDUy745eKAvWXkEwEUqYrjiWEej6R979d0kixu16FMXyIbq1PaXbFdoHJKwlVNos6BVvCskqbHMmBDtQ==",
-      "license": "MIT",
+      "version": "3.77.1",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.77.1.tgz",
+      "integrity": "sha512-MWARsWO6ZbZUlH9wQslZzTbzi9sKOPWuHjQ7f/F6+uZaM3OIbOZNO5ilxijv0XlmGjNpfDQYdE3HhQV+RQY4nQ==",
       "dependencies": {
         "@babel/traverse": "^7.23.5",
-        "@sanity/client": "^6.27.2",
-        "@sanity/codegen": "3.74.1",
+        "@sanity/client": "^6.28.1",
+        "@sanity/codegen": "3.77.1",
         "@sanity/telemetry": "^0.7.7",
         "@sanity/template-validator": "^2.4.0",
-        "@sanity/util": "3.74.1",
+        "@sanity/util": "3.77.1",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
         "decompress": "^4.2.0",
@@ -4223,7 +4307,6 @@
       "cpu": [
         "ppc64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -4239,7 +4322,6 @@
       "cpu": [
         "arm"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -4255,7 +4337,6 @@
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -4271,7 +4352,6 @@
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -4287,7 +4367,6 @@
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4303,7 +4382,6 @@
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4319,7 +4397,6 @@
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -4335,7 +4412,6 @@
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -4351,7 +4427,6 @@
       "cpu": [
         "arm"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4367,7 +4442,6 @@
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4383,7 +4457,6 @@
       "cpu": [
         "ia32"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4399,7 +4472,6 @@
       "cpu": [
         "loong64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4415,7 +4487,6 @@
       "cpu": [
         "mips64el"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4431,7 +4502,6 @@
       "cpu": [
         "ppc64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4447,7 +4517,6 @@
       "cpu": [
         "riscv64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4463,7 +4532,6 @@
       "cpu": [
         "s390x"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4479,7 +4547,6 @@
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4495,7 +4562,6 @@
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -4511,7 +4577,6 @@
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -4527,7 +4592,6 @@
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -4543,7 +4607,6 @@
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4559,7 +4622,6 @@
       "cpu": [
         "ia32"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4575,7 +4637,6 @@
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4588,7 +4649,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4603,7 +4663,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4620,7 +4679,6 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4657,7 +4715,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4669,16 +4726,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
-      "license": "ISC",
       "dependencies": {
         "builtins": "^1.0.3"
       }
     },
     "node_modules/@sanity/client": {
-      "version": "6.27.2",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.27.2.tgz",
-      "integrity": "sha512-x5KaN5atPnEFa3GGSH3YKSAYh1MAECvEs9o+NSLd5W19imxvSxPquQBv0Q60Zdsg6iaTJPAAa79Ak5Xyg2FHvA==",
-      "license": "MIT",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.28.1.tgz",
+      "integrity": "sha512-SPMr3IbFTHjLXB779GX7eDVZiNgNslbQkeGMC1ZWJnvs8zGGPU+wZo7goNC7EeMfP93+WOlt4UKLPVX5NfCW6g==",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
         "get-it": "^8.6.7",
@@ -4813,10 +4868,9 @@
       }
     },
     "node_modules/@sanity/codegen": {
-      "version": "3.74.1",
-      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.74.1.tgz",
-      "integrity": "sha512-hPCWjQR6UHUyH/IslN9WYwPQCb9ckj8NGiqMPSZupWhjAMzHytdK7QeBdRAF+1wwuJ5d082N5bv+2x8AXyNeKA==",
-      "license": "MIT",
+      "version": "3.77.1",
+      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.77.1.tgz",
+      "integrity": "sha512-qIXbhtzfpWdc6oDAuKQkSOUCZN24XVrxD0npkicdtgcd0Z9UV8lhE9jEdkMBSMEbPfi195CRG1f8E7GNDpF5+A==",
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/generator": "^7.23.6",
@@ -4828,7 +4882,7 @@
         "@babel/types": "^7.23.9",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
-        "groq": "3.74.1",
+        "groq": "3.77.1",
         "groq-js": "^1.15.0",
         "json5": "^2.2.3",
         "tsconfig-paths": "^4.2.0",
@@ -4850,7 +4904,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sanity/comlink/-/comlink-3.0.1.tgz",
       "integrity": "sha512-I1F57GKL69xoJUF9/4XTMvXFJZ7BnaFmTBIaiRvXaovJEZ677p5f+UkURPG/dd9L63+OnTV0SNmhTjIIzNexdw==",
-      "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.1",
         "uuid": "^11.0.5",
@@ -4861,10 +4914,9 @@
       }
     },
     "node_modules/@sanity/diff": {
-      "version": "3.74.1",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.74.1.tgz",
-      "integrity": "sha512-dtjJNWcjt8JLZab62WQLFDyfIT+Gbjea0vYP73p91mnBWssaZv2XvP3dNoHVP8tl989quo0q6DqL8Q/XGr1Vmw==",
-      "license": "MIT",
+      "version": "3.77.1",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.77.1.tgz",
+      "integrity": "sha512-JqaP40/bWdputDuRqu0NWDxHSmR1rsvCEBwaKuuKuuRw2mT2kwCfCIpDJwC1udTvOqlYOLR0mIJhZyJiry06NA==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1"
       },
@@ -4879,6 +4931,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
+      }
+    },
+    "node_modules/@sanity/diff-patch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/diff-patch/-/diff-patch-5.0.0.tgz",
+      "integrity": "sha512-JASdNaZsxUFBx8GQ1sX2XehYhdhOcurh7KwzQ3cXgOTdjvIQyQcLwmMeYCsU/K26GiI81ODbCEb/C0c92t2Unw==",
+      "dependencies": {
+        "@sanity/diff-match-patch": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=18.2"
       }
     },
     "node_modules/@sanity/document-internationalization": {
@@ -4904,9 +4967,9 @@
       }
     },
     "node_modules/@sanity/document-internationalization/node_modules/sanity-plugin-internationalized-array": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/sanity-plugin-internationalized-array/-/sanity-plugin-internationalized-array-3.1.0.tgz",
-      "integrity": "sha512-mf+BFF9EcvKrF8fHOMfp2lah7m5H+7mdPC4SmivwVDvKcR16CzYmEI9tGx5CeGw+xK044EPaWFVUdApLN/Z7uA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/sanity-plugin-internationalized-array/-/sanity-plugin-internationalized-array-3.1.1.tgz",
+      "integrity": "sha512-ohu8ev5VUAmWGZOESmelhj01oydckgtTK0wDTaZvNs+O0mRJijkKZEqj5uJFP/e2fRClyRje36RLUCA4d6MmFw==",
       "dependencies": {
         "@sanity/icons": "^3.5.3",
         "@sanity/incompatible-plugin": "^1.0.5",
@@ -5214,9 +5277,9 @@
       "integrity": "sha512-wtMYcV5GIDIhVyF/jjmdwq1GdlK07dRL40XMns73VbrFI7FteRltxv48bhYVZPcLkRXb0SHjpDS/icj9/yzbVA=="
     },
     "node_modules/@sanity/icons": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-3.5.7.tgz",
-      "integrity": "sha512-Gdqh1Cst/GL2RF23Ztx14hFEOBltK7PYMDHTi83TQ4Vq2/W0rhhMTVlaAopb4MgnUBwzISHRLD85SuvDMi9SuA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-3.6.0.tgz",
+      "integrity": "sha512-GFSJiDYW5eEKnkedz7J+RQDcjcG6UBL1DzrXdddRD+CI9IKBDSBTrfnw9qjZbi6R5NeXXRBCTnKW34rOCAocpw==",
       "engines": {
         "node": ">=14.0.0"
       },
@@ -5468,14 +5531,14 @@
       }
     },
     "node_modules/@sanity/insert-menu": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@sanity/insert-menu/-/insert-menu-1.0.20.tgz",
-      "integrity": "sha512-oYhGCerabMOJBU47ukjY5Hq6g87yHlN8Xr/HaqNLGG7ustGaT6cWA4UMaDuWd980qbWeC3s9Ph6cKRT/Sy8JtA==",
-      "license": "MIT",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@sanity/insert-menu/-/insert-menu-1.1.3.tgz",
+      "integrity": "sha512-KcslD8rbgRC6JVrROJ1T2Wi6+44BwYtMcswGQsxE++CpZ3XYab8hf4P5huVFdNDQwM+XshIPQAjmsa1B2XUAfw==",
       "dependencies": {
-        "@sanity/icons": "^3.5.7",
-        "@sanity/ui": "^2.11.4",
-        "lodash": "^4.17.21"
+        "@sanity/icons": "^3.6.0",
+        "@sanity/ui": "^2.14.2",
+        "lodash": "^4.17.21",
+        "react-compiler-runtime": "19.0.0-beta-e1e972c-20250221"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -5485,6 +5548,14 @@
         "react": "^18.3 || >=19.0.0-rc",
         "react-dom": "^18.3 || >=19.0.0-rc",
         "react-is": "^18.3 || >=19.0.0-rc"
+      }
+    },
+    "node_modules/@sanity/insert-menu/node_modules/react-compiler-runtime": {
+      "version": "19.0.0-beta-e1e972c-20250221",
+      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.0.0-beta-e1e972c-20250221.tgz",
+      "integrity": "sha512-6nONLW+4zbfAt6mLG6SV73tKlZLJqmezqX0EF9ZKzab84Pje/4CMVs8QVw4OeRS+FFtPcfWU4fOK28nq7lM4Hg==",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
       }
     },
     "node_modules/@sanity/language-filter": {
@@ -5520,15 +5591,14 @@
       }
     },
     "node_modules/@sanity/migrate": {
-      "version": "3.74.1",
-      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-3.74.1.tgz",
-      "integrity": "sha512-NsA28RKztkx3TQlu4c7/YFer82vhMK2rvZeckC2kYLoAoscu4x2voVOL0v1sEieOLRVGMca0TXMV3ngzbdnN3A==",
-      "license": "MIT",
+      "version": "3.77.1",
+      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-3.77.1.tgz",
+      "integrity": "sha512-3fetJGMd0dndJds5KIFp43dU45zZlzxD8F5pIEuS57+t2jKDe3XXlOAN+XGm7EJFhw00b6uTYbIoGMeU0ucxYA==",
       "dependencies": {
-        "@sanity/client": "^6.27.2",
+        "@sanity/client": "^6.28.1",
         "@sanity/mutate": "^0.12.1",
-        "@sanity/types": "3.74.1",
-        "@sanity/util": "3.74.1",
+        "@sanity/types": "3.77.1",
+        "@sanity/util": "3.77.1",
         "arrify": "^2.0.1",
         "debug": "^4.3.4",
         "fast-fifo": "^1.3.2",
@@ -5543,7 +5613,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
       "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -5555,7 +5624,6 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@sanity/mutate/-/mutate-0.12.1.tgz",
       "integrity": "sha512-SuOpMOEwcTcE5fFHpy44qVuGs8NeBAOF8wwN5DYz0Jl4MJZWGsUS81YUeFwQl0XqBZpfiLVzwutp1KYCZPuqUQ==",
-      "license": "MIT",
       "dependencies": {
         "@sanity/client": "^6.24.1",
         "@sanity/diff-match-patch": "^3.1.1",
@@ -5571,16 +5639,15 @@
       }
     },
     "node_modules/@sanity/mutate/node_modules/nanoid": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.9.tgz",
-      "integrity": "sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.2.tgz",
+      "integrity": "sha512-b+CiXQCNMUGe0Ri64S9SXFcP9hogjAJ2Rd6GdVxhPLRm7mhGaM7VgOvCAJ1ZshfHbqVDI3uqTI5C8/GaKuLI7g==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.js"
       },
@@ -5589,27 +5656,26 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.74.1",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.74.1.tgz",
-      "integrity": "sha512-Bvy5dRCoemV4K3TQKWqSfoC+P6vbd26dmktiqiS/IFtj83HQp0bh5LBAPUt/ZUTdfSV1bpeTfuzQELTvpXkTwA==",
-      "license": "MIT",
+      "version": "3.77.1",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.77.1.tgz",
+      "integrity": "sha512-q0ch6qd2mExRQkHhRZdM6HHOGxLOsjQjTqZY9GimX+cXNz1owCqMNF9kb33AHdPeRJkZqkJD4iKF/u4RVkKDtA==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1",
-        "@sanity/types": "3.74.1",
+        "@sanity/types": "3.77.1",
         "@sanity/uuid": "^3.0.1",
         "debug": "^4.3.4",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@sanity/pkg-utils": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/@sanity/pkg-utils/-/pkg-utils-6.13.3.tgz",
-      "integrity": "sha512-RelSmFTfJQMIu7Q03/FVmnCcCJWCbI4CQH5V4cIy1xFh/NkgI8Bj5pCkD8SPa65b9dBWpVBsQpwEi7Asj2lu2g==",
+      "version": "6.13.4",
+      "resolved": "https://registry.npmjs.org/@sanity/pkg-utils/-/pkg-utils-6.13.4.tgz",
+      "integrity": "sha512-m4x0qyu2wiUHKuVxy/B2kcQRh20RvsyvUlUjPbiM5ENt4hwpJPLFfxtPe53GOCf3NJfcSK/te4yQkMOyL8RzAA==",
       "dependencies": {
         "@babel/core": "^7.26.0",
         "@babel/preset-typescript": "^7.26.0",
         "@babel/types": "^7.26.3",
-        "@microsoft/api-extractor": "7.49.0",
+        "@microsoft/api-extractor": "7.48.1",
         "@microsoft/tsdoc-config": "0.17.1",
         "@optimize-lodash/rollup-plugin": "5.0.0",
         "@rollup/plugin-alias": "^5.1.1",
@@ -5663,6 +5729,61 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@microsoft/api-extractor": {
+      "version": "7.48.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.48.1.tgz",
+      "integrity": "sha512-HN9Osa1WxqLM66RaqB5nPAadx+nTIQmY/XtkFdaJvusjG8Tus++QqZtD7KPZDSkhEMGHsYeSyeU8qUzCDUXPjg==",
+      "dependencies": {
+        "@microsoft/api-extractor-model": "7.30.1",
+        "@microsoft/tsdoc": "~0.15.1",
+        "@microsoft/tsdoc-config": "~0.17.1",
+        "@rushstack/node-core-library": "5.10.1",
+        "@rushstack/rig-package": "0.5.3",
+        "@rushstack/terminal": "0.14.4",
+        "@rushstack/ts-command-line": "4.23.2",
+        "lodash": "~4.17.15",
+        "minimatch": "~3.0.3",
+        "resolve": "~1.22.1",
+        "semver": "~7.5.4",
+        "source-map": "~0.6.1",
+        "typescript": "5.4.2"
+      },
+      "bin": {
+        "api-extractor": "bin/api-extractor"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@microsoft/api-extractor/node_modules/minimatch": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@sanity/pkg-utils/node_modules/ansi-styles": {
@@ -5719,6 +5840,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@sanity/pkg-utils/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@sanity/pkg-utils/node_modules/minimatch": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
@@ -5758,6 +5890,20 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@sanity/pkg-utils/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@sanity/pkg-utils/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5768,6 +5914,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@sanity/plugin-kit": {
       "version": "3.1.12",
@@ -6736,19 +6887,18 @@
       }
     },
     "node_modules/@sanity/presentation-comlink": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@sanity/presentation-comlink/-/presentation-comlink-1.0.5.tgz",
-      "integrity": "sha512-R3SN7rckwhnpWAIbm0KzTKQD3F1Dss/BXlchK0MHEmVRWKIylnfHBzSEuOAq910HrZnRGkeUvwjtxHT2gASDYw==",
-      "license": "MIT",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@sanity/presentation-comlink/-/presentation-comlink-1.0.8.tgz",
+      "integrity": "sha512-8yOj3PIXDb1x2U/81/Eeu7w3CC5BmUUpD0vN2FMoviBQ9okCR7UXxOtRHpSUjmJlI1E4AobVUWUgzqCGx77xKg==",
       "dependencies": {
         "@sanity/comlink": "^3.0.1",
-        "@sanity/visual-editing-types": "^1.0.5"
+        "@sanity/visual-editing-types": "^1.0.8"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/client": "^6.27.2"
+        "@sanity/client": "^6.28.0"
       }
     },
     "node_modules/@sanity/preview-url-secret": {
@@ -6767,13 +6917,12 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "3.74.1",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.74.1.tgz",
-      "integrity": "sha512-aPYMgsx8rSJEcn7EYlS4mgS08v957VRhsI4wEiGDvrjwRC1UCkiHPKwxPAvzkbJY1OnWS4+3AJysokx01qKAxQ==",
-      "license": "MIT",
+      "version": "3.77.1",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.77.1.tgz",
+      "integrity": "sha512-QleHjkrLr0ycLaCxRA7afI8/N6/R5/hn1NhJglBAWf72ldlvWNHxWLhcIxapo3cq5FixzwfBQcG22E7RAujDuw==",
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.74.1",
+        "@sanity/types": "3.77.1",
         "arrify": "^2.0.1",
         "groq-js": "^1.15.0",
         "humanize-list": "^1.0.1",
@@ -6817,7 +6966,6 @@
       "version": "0.7.9",
       "resolved": "https://registry.npmjs.org/@sanity/telemetry/-/telemetry-0.7.9.tgz",
       "integrity": "sha512-TBBRK2SUwiNND+ZJPwdWSu8tbEjdIz7UjagmCCBBWcfXtDKXXlWawC/DOEWuI4Q+WcA5OWLDjboxZT4ApWjVbw==",
-      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
         "rxjs": "^7.8.1",
@@ -6834,7 +6982,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@sanity/template-validator/-/template-validator-2.4.0.tgz",
       "integrity": "sha512-gkQ4hPbfad7CtLrl5ZFReqKbFEBf9ijsyqNJaKny53QTMlyGgwL0JKxiM+bwAiU0uOUT0vSqdzSAxDJNF0BDpg==",
-      "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",
@@ -6850,30 +6997,28 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "3.74.1",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.74.1.tgz",
-      "integrity": "sha512-VjV2ZrGXJFYAReoYZ/ea/lMATSqM6utfkYn7mxRm+S6b7lBRaTwQ5uvG2dlbUNjaKGJ2YmrWLh9872hIB94AKw==",
-      "license": "MIT",
+      "version": "3.77.1",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.77.1.tgz",
+      "integrity": "sha512-SD2/k3ymGRxoqqalKiCSbwqwVY6iBNPv81b52UwZHqqPkpIhA5eetreLDwZfwdj5VVwWOjp7n/xyx0m/nThlCQ==",
       "dependencies": {
-        "@sanity/client": "^6.27.2"
+        "@sanity/client": "^6.28.1"
       },
       "peerDependencies": {
         "@types/react": "18 || 19"
       }
     },
     "node_modules/@sanity/ui": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-2.12.2.tgz",
-      "integrity": "sha512-HzuZ54nmC7mSdyOUtiu3T31vzVouiQd7780aS6M/SaGGPptYxJ2gwxlrlU6KEaOM+VkjLt6Dk3ewDA7T4sNcbg==",
-      "license": "MIT",
+      "version": "2.14.3",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-2.14.3.tgz",
+      "integrity": "sha512-YtaMKIaGy9wcE+Y4hcGNZS+xNkxjoYynRr6j9dgd8BPxCiD56FmRS0A9w0+wHRq5Rh8bTWRT4ZrOdThLxqsgJw==",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.2",
         "@juggle/resize-observer": "^3.4.0",
         "@sanity/color": "^3.0.6",
-        "@sanity/icons": "^3.5.7",
+        "@sanity/icons": "^3.6.0",
         "csstype": "^3.1.3",
-        "framer-motion": "^12.4.1",
-        "react-compiler-runtime": "19.0.0-beta-714736e-20250131",
+        "framer-motion": "^12.4.7",
+        "react-compiler-runtime": "19.0.0-beta-e1e972c-20250221",
         "react-refractor": "^2.2.0",
         "use-effect-event": "^1.0.2"
       },
@@ -6888,22 +7033,20 @@
       }
     },
     "node_modules/@sanity/ui/node_modules/react-compiler-runtime": {
-      "version": "19.0.0-beta-714736e-20250131",
-      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.0.0-beta-714736e-20250131.tgz",
-      "integrity": "sha512-RJQqbR2zIobjLZ242MRQlWlyxLDxw0fRxbniImHxSsBqHSf35vK8CsClA37MfO729M3n4jCIawI3BCdBHksOvA==",
-      "license": "MIT",
+      "version": "19.0.0-beta-e1e972c-20250221",
+      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.0.0-beta-e1e972c-20250221.tgz",
+      "integrity": "sha512-6nONLW+4zbfAt6mLG6SV73tKlZLJqmezqX0EF9ZKzab84Pje/4CMVs8QVw4OeRS+FFtPcfWU4fOK28nq7lM4Hg==",
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
       }
     },
     "node_modules/@sanity/util": {
-      "version": "3.74.1",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.74.1.tgz",
-      "integrity": "sha512-wwRR0r3dB1+O4DFHZfsFD698wqnIcTFLpbUD/oerVvD/Q3pL/ntveomcZFQ8sZancsBg/z4+41D/6mt7x0BQNg==",
-      "license": "MIT",
+      "version": "3.77.1",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.77.1.tgz",
+      "integrity": "sha512-zbnAx98EZeVYWdFGEn+9vSmjfcbW3l3SccY7eOVtydA/dVlZ6khci2/83HQhN5Dgym3DOP9yCSyde8BZSPpklg==",
       "dependencies": {
-        "@sanity/client": "^6.27.2",
-        "@sanity/types": "3.74.1",
+        "@sanity/client": "^6.28.1",
+        "@sanity/types": "3.77.1",
         "get-random-values-esm": "1.0.2",
         "moment": "^2.30.1",
         "rxjs": "^7.8.1"
@@ -6971,15 +7114,14 @@
       }
     },
     "node_modules/@sanity/visual-editing-types": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-1.0.5.tgz",
-      "integrity": "sha512-iRTgMU53P6vv2tGAi/mrGSfZIlMnQ9S2UQB8v2qC/YDxETNpRec3+00mW/pc3IlrPjE7dIOjI6dWHgLG3cSLFg==",
-      "license": "MIT",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-1.0.8.tgz",
+      "integrity": "sha512-LxbMtM6Q8E+xWSfAnvHMHDPO128axgejEGqjWZUo2EacKEgcuH5MN9JFnKeHu2E8jc3x7TlBYkDXWhG6iUxy5g==",
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/client": "^6.27.2",
+        "@sanity/client": "^6.28.0",
         "@sanity/types": "*"
       },
       "peerDependenciesMeta": {
@@ -7149,75 +7291,6 @@
         "semantic-release": ">=20.1.0"
       }
     },
-    "node_modules/@semantic-release/github/node_modules/@octokit/auth-token": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
-      "integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/@octokit/core": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.3.tgz",
-      "integrity": "sha512-z+j7DixNnfpdToYsOutStDgeRzJSMnbj8T1C/oQjB6Aa+kRfNjs/Fn7W6c8bmlt6mfy3FkgeKBRnDjxQow5dow==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/auth-token": "^5.0.0",
-        "@octokit/graphql": "^8.1.2",
-        "@octokit/request": "^9.1.4",
-        "@octokit/request-error": "^6.1.6",
-        "@octokit/types": "^13.6.2",
-        "before-after-hook": "^3.0.2",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/@octokit/endpoint": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.2.tgz",
-      "integrity": "sha512-XybpFv9Ms4hX5OCHMZqyODYqGTZ3H6K6Vva+M9LR7ib/xr1y1ZnlChYv9H680y77Vd/i/k+thXApeRASBQkzhA==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^13.6.2",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/@octokit/graphql": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.2.tgz",
-      "integrity": "sha512-bdlj/CJVjpaz06NBpfHhp4kGJaRZfz7AzC+6EwUImRtrwIw8dIgJ63Xg0OzV9pRn3rIzrt5c2sa++BL0JJ8GLw==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/request": "^9.1.4",
-        "@octokit/types": "^13.6.2",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/@octokit/plugin-paginate-rest": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.6.tgz",
-      "integrity": "sha512-zcvqqf/+TicbTCa/Z+3w4eBJcAxCFymtc0UAIsR3dEVoNilWld4oXdscQ3laXamTszUZdusw97K8+DrbFiOwjw==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^13.6.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
     "node_modules/@semantic-release/github/node_modules/@octokit/plugin-retry": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.1.3.tgz",
@@ -7251,34 +7324,6 @@
         "@octokit/core": "^6.0.0"
       }
     },
-    "node_modules/@semantic-release/github/node_modules/@octokit/request": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.4.tgz",
-      "integrity": "sha512-tMbOwGm6wDII6vygP3wUVqFTw3Aoo0FnVQyhihh8vVq12uO3P+vQZeo2CKMpWtPSogpACD0yyZAlVlQnjW71DA==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/endpoint": "^10.0.0",
-        "@octokit/request-error": "^6.0.1",
-        "@octokit/types": "^13.6.2",
-        "fast-content-type-parse": "^2.0.0",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/@octokit/request-error": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.6.tgz",
-      "integrity": "sha512-pqnVKYo/at0NuOjinrgcQYpEbv4snvP3bKMRqHaD9kIsk9u1LCpb2smHZi8/qJfgeNqLo5hNW4Z7FezNdEo0xg==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^13.6.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
@@ -7303,12 +7348,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@semantic-release/github/node_modules/before-after-hook": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
-      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
-      "dev": true
     },
     "node_modules/@semantic-release/github/node_modules/clean-stack": {
       "version": "5.2.0",
@@ -7392,12 +7431,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@semantic-release/github/node_modules/universal-user-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
-      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
-      "dev": true
     },
     "node_modules/@semantic-release/npm": {
       "version": "12.0.1",
@@ -8651,13 +8684,13 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.0.tgz",
-      "integrity": "sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "1.6.0",
-        "@vitest/utils": "1.6.0",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
         "chai": "^4.3.10"
       },
       "funding": {
@@ -8665,12 +8698,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.0.tgz",
-      "integrity": "sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "1.6.0",
+        "@vitest/utils": "1.6.1",
         "p-limit": "^5.0.0",
         "pathe": "^1.1.1"
       },
@@ -8694,9 +8727,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.0.tgz",
-      "integrity": "sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
       "dev": true,
       "dependencies": {
         "magic-string": "^0.30.5",
@@ -8708,9 +8741,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.0.tgz",
-      "integrity": "sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.2.0"
@@ -8720,9 +8753,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.0.tgz",
-      "integrity": "sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
       "dev": true,
       "dependencies": {
         "diff-sequences": "^29.6.3",
@@ -8747,7 +8780,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@xstate/react/-/react-5.0.2.tgz",
       "integrity": "sha512-x5GOrE0ZYjU2ba986u0CCp7SaPwzElSn1SW0mZ9MuBgsZ+BW7vTLVOvGmURynwojdso8d6nVbK3c2+MRVqGVgA==",
-      "license": "MIT",
       "dependencies": {
         "use-isomorphic-layout-effect": "^1.1.2",
         "use-sync-external-store": "^1.2.0"
@@ -9268,7 +9300,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -9474,10 +9505,9 @@
       ]
     },
     "node_modules/before-after-hook": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-      "license": "Apache-2.0"
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
@@ -9605,7 +9635,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "license": "MIT",
       "dependencies": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -9614,8 +9643,7 @@
     "node_modules/buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "license": "MIT"
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
     "node_modules/buffer-crc32": {
       "version": "1.0.0",
@@ -9628,8 +9656,7 @@
     "node_modules/buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
-      "license": "MIT"
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -9639,8 +9666,7 @@
     "node_modules/builtins": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-      "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
-      "license": "MIT"
+      "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ=="
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -10161,7 +10187,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
       "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-      "license": "MIT",
       "dependencies": {
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
@@ -10317,8 +10342,7 @@
     "node_modules/compute-scroll-into-view": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
-      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
-      "license": "MIT"
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -10975,7 +10999,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
       "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
-      "license": "MIT",
       "dependencies": {
         "decompress-tar": "^4.0.0",
         "decompress-tarbz2": "^4.0.0",
@@ -11008,7 +11031,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
-      "license": "MIT",
       "dependencies": {
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0",
@@ -11022,7 +11044,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
       "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
-      "license": "MIT",
       "dependencies": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -11032,7 +11053,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11040,14 +11060,12 @@
     "node_modules/decompress-tar/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/decompress-tar/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -11061,14 +11079,12 @@
     "node_modules/decompress-tar/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/decompress-tar/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -11077,7 +11093,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-      "license": "MIT",
       "dependencies": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
@@ -11095,7 +11110,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
-      "license": "MIT",
       "dependencies": {
         "decompress-tar": "^4.1.0",
         "file-type": "^6.1.0",
@@ -11111,7 +11125,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
       "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -11120,7 +11133,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11129,7 +11141,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
-      "license": "MIT",
       "dependencies": {
         "decompress-tar": "^4.1.1",
         "file-type": "^5.2.0",
@@ -11143,7 +11154,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11152,7 +11162,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
-      "license": "MIT",
       "dependencies": {
         "file-type": "^3.8.0",
         "get-stream": "^2.2.0",
@@ -11167,7 +11176,6 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
       "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11176,7 +11184,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
       "integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
-      "license": "MIT",
       "dependencies": {
         "object-assign": "^4.0.1",
         "pinkie-promise": "^2.0.0"
@@ -11189,7 +11196,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-      "license": "MIT",
       "dependencies": {
         "pify": "^3.0.0"
       },
@@ -11201,7 +11207,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -11310,8 +11315,7 @@
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-      "license": "ISC"
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "node_modules/detect-indent": {
       "version": "7.0.1",
@@ -11365,7 +11369,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
       "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
-      "license": "MIT",
       "bin": {
         "direction": "cli.js"
       },
@@ -11456,9 +11459,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
-      "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -12614,7 +12617,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
       "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12707,7 +12709,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -12776,7 +12777,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
       "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -12817,7 +12817,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
       "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-      "license": "MIT",
       "dependencies": {
         "commondir": "^1.0.1",
         "make-dir": "^2.0.0",
@@ -12831,7 +12830,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "license": "MIT",
       "dependencies": {
         "locate-path": "^3.0.0"
       },
@@ -12843,7 +12841,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "license": "MIT",
       "dependencies": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -12856,7 +12853,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -12871,7 +12867,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.0.0"
       },
@@ -12883,7 +12878,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -12892,7 +12886,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-      "license": "MIT",
       "dependencies": {
         "find-up": "^3.0.0"
       },
@@ -13068,12 +13061,11 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.4.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.4.1.tgz",
-      "integrity": "sha512-5Ijbea3topSZjadQ0hgc/TcWj2ldMZmNREM7RvAhvsThYOA1HHOA8TT1yKvMu1YXP3jWaFwoZ6Vo9Nw+DUZrzA==",
-      "license": "MIT",
+      "version": "12.4.7",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.4.7.tgz",
+      "integrity": "sha512-VhrcbtcAMXfxlrjeHPpWVu2+mkcoR31e02aNSR7OUS/hZAciKa8q6o3YN2mA1h+jjscRsSyKvX6E1CiY/7OLMw==",
       "dependencies": {
-        "motion-dom": "^12.0.0",
+        "motion-dom": "^12.4.5",
         "motion-utils": "^12.0.0",
         "tslib": "^2.4.0"
       },
@@ -13773,10 +13765,9 @@
       "dev": true
     },
     "node_modules/groq": {
-      "version": "3.74.1",
-      "resolved": "https://registry.npmjs.org/groq/-/groq-3.74.1.tgz",
-      "integrity": "sha512-nQq2qlCTFNhkBZJ4tHY1tXQHEZDlqg/iFOtQIF5PEJNqrTG7/GQrHKwKlTjfcbq+qnJys2t45qVn10uLZAteZA==",
-      "license": "MIT",
+      "version": "3.77.1",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-3.77.1.tgz",
+      "integrity": "sha512-4JHVAqrE1A9OWVRLOdCTVQAgArMm7SV1JIUAyrPwiQhvLXg+qodI3cDw522/1/kfAFP6cGAO2f9oVoAW8XI76Q==",
       "engines": {
         "node": ">=18"
       }
@@ -13785,7 +13776,6 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-1.15.0.tgz",
       "integrity": "sha512-PB0phOsvoYq6V5G5K5nOUDhzHH6NaqlzSaUmjBNS487kU/CJ0m2xIuvbnZM5nz1oC1jfDpCW3IXh3GKpMpU5Pw==",
-      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -14013,8 +14003,7 @@
     "node_modules/hotscript": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/hotscript/-/hotscript-1.0.13.tgz",
-      "integrity": "sha512-C++tTF1GqkGYecL+2S1wJTfoH6APGAsbb7PAWQ3iVIwgG/EFseAfEVOKFgAFq4yK3+6j1EjUD4UQ9dRJHX/sSQ==",
-      "license": "ISC"
+      "integrity": "sha512-C++tTF1GqkGYecL+2S1wJTfoH6APGAsbb7PAWQ3iVIwgG/EFseAfEVOKFgAFq4yK3+6j1EjUD4UQ9dRJHX/sSQ=="
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -14071,8 +14060,7 @@
     "node_modules/humanize-list": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/humanize-list/-/humanize-list-1.0.1.tgz",
-      "integrity": "sha512-4+p3fCRF21oUqxhK0yZ6yaSP/H5/wZumc7q1fH99RkW7Q13aAxDeP78BKjoR+6y+kaHqKF/JWuQhsNuuI2NKtA==",
-      "license": "MIT"
+      "integrity": "sha512-4+p3fCRF21oUqxhK0yZ6yaSP/H5/wZumc7q1fH99RkW7Q13aAxDeP78BKjoR+6y+kaHqKF/JWuQhsNuuI2NKtA=="
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -14711,8 +14699,7 @@
     "node_modules/is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-      "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
-      "license": "MIT"
+      "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ=="
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -14770,7 +14757,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -15015,7 +15001,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15452,7 +15437,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -16174,7 +16158,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "license": "MIT",
       "dependencies": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
@@ -16187,7 +16170,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -16196,7 +16178,6 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -16295,7 +16276,6 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/mendoza/-/mendoza-3.0.8.tgz",
       "integrity": "sha512-iwxgEpSOx9BDLJMD0JAzNicqo9xdrvzt6w/aVwBKMndlA6z/DH41+o60H2uHB0vCR1Xr37UOgu9xFWJHvYsuKw==",
-      "license": "MIT",
       "engines": {
         "node": ">=14.18"
       }
@@ -16635,10 +16615,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.0.0.tgz",
-      "integrity": "sha512-CvYd15OeIR6kHgMdonCc1ihsaUG4MYh/wrkz8gZ3hBX/uamyZCXN9S9qJoYF03GqfTt7thTV/dxnHYX4+55vDg==",
-      "license": "MIT",
+      "version": "12.4.5",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.4.5.tgz",
+      "integrity": "sha512-Q2xmhuyYug1CGTo0jdsL05EQ4RhIYXlggFS/yPhQQRNzbrhjKQ1tbjThx5Plv68aX31LsUQRq4uIkuDxdO5vRQ==",
       "dependencies": {
         "motion-utils": "^12.0.0"
       }
@@ -16646,8 +16625,7 @@
     "node_modules/motion-utils": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.0.0.tgz",
-      "integrity": "sha512-MNFiBKbbqnmvOjkPyOKgHUp3Q6oiokLkI1bEwm5QA28cxMZrv0CbbBGDNmhF6DIXsi1pCQBSs0dX8xjeER1tmA==",
-      "license": "MIT"
+      "integrity": "sha512-MNFiBKbbqnmvOjkPyOKgHUp3Q6oiokLkI1bEwm5QA28cxMZrv0CbbBGDNmhF6DIXsi1pCQBSs0dX8xjeER1tmA=="
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -20031,7 +20009,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/observable-callback/-/observable-callback-1.0.3.tgz",
       "integrity": "sha512-VlS275UyPnwdMtzxDgr/lCiOUyq9uXNll3vdwzDcJ6PB/LuO7gLmxAQopcCA3JoFwwujBwyA7/tP5TXZwWSXew==",
-      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -20700,8 +20677,7 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -20740,7 +20716,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20749,7 +20724,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20758,7 +20732,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
-      "license": "MIT",
       "dependencies": {
         "pinkie": "^2.0.0"
       },
@@ -20770,7 +20743,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -20859,7 +20831,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
       "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-      "license": "MIT",
       "dependencies": {
         "find-up": "^5.0.0"
       },
@@ -20871,7 +20842,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -20887,7 +20857,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -20902,7 +20871,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -20917,7 +20885,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -20932,7 +20899,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -20941,7 +20907,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -21063,9 +21028,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -21080,7 +21045,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -21644,13 +21608,12 @@
       }
     },
     "node_modules/react-rx": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-4.1.18.tgz",
-      "integrity": "sha512-q3QiZi/cmOA2eUlK9UKba1qfziw11D3mwKtVTw/J85tbSQjvM2lK8JJ1HG2+4gJ43zZAVTd9lrf6NCtAKpK9xQ==",
-      "license": "MIT",
+      "version": "4.1.21",
+      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-4.1.21.tgz",
+      "integrity": "sha512-sMDf3jPo6CY+ATtkta9oA8l7XvYrTDIg0uDPDcP51iv8812pJp/dUSOokfP+WcsGHnFN7OPzsHS/T4+QwuBLvA==",
       "dependencies": {
         "observable-callback": "^1.0.3",
-        "react-compiler-runtime": "19.0.0-beta-714736e-20250131",
+        "react-compiler-runtime": "19.0.0-beta-e1e972c-20250221",
         "use-effect-event": "^1.0.2"
       },
       "peerDependencies": {
@@ -21659,10 +21622,9 @@
       }
     },
     "node_modules/react-rx/node_modules/react-compiler-runtime": {
-      "version": "19.0.0-beta-714736e-20250131",
-      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.0.0-beta-714736e-20250131.tgz",
-      "integrity": "sha512-RJQqbR2zIobjLZ242MRQlWlyxLDxw0fRxbniImHxSsBqHSf35vK8CsClA37MfO729M3n4jCIawI3BCdBHksOvA==",
-      "license": "MIT",
+      "version": "19.0.0-beta-e1e972c-20250221",
+      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.0.0-beta-e1e972c-20250221.tgz",
+      "integrity": "sha512-6nONLW+4zbfAt6mLG6SV73tKlZLJqmezqX0EF9ZKzab84Pje/4CMVs8QVw4OeRS+FFtPcfWU4fOK28nq7lM4Hg==",
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
       }
@@ -22377,9 +22339,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -22478,45 +22440,45 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanity": {
-      "version": "3.74.1",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.74.1.tgz",
-      "integrity": "sha512-ZHM4LTMSJHq2mgkg3+SUOaE45Yq80HEj7lcxQ6pnLxXnfWwc1YfIWfFZqzO4RmavnzlKJcCVN7IJ7gelaJbW/g==",
-      "license": "MIT",
+      "version": "3.77.1",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.77.1.tgz",
+      "integrity": "sha512-ZTaW1fDV3aish8LZTj9vEhyAstbMUjV9BkYaoMAR1L7xuq2/GgEVr6rCmFuc5NE0po+FJ90uaPmUTxTDfGYEqw==",
       "dependencies": {
         "@dnd-kit/core": "^6.0.5",
         "@dnd-kit/modifiers": "^6.0.0",
         "@dnd-kit/sortable": "^7.0.1",
         "@dnd-kit/utilities": "^3.2.0",
         "@juggle/resize-observer": "^3.3.1",
-        "@portabletext/block-tools": "^1.1.4",
-        "@portabletext/editor": "^1.30.3",
+        "@portabletext/block-tools": "^1.1.9",
+        "@portabletext/editor": "^1.35.4",
         "@portabletext/react": "^3.0.0",
         "@portabletext/toolkit": "^2.0.16",
         "@rexxars/react-json-inspector": "^9.0.1",
         "@sanity/asset-utils": "^2.0.6",
         "@sanity/bifur-client": "^0.4.1",
-        "@sanity/cli": "3.74.1",
-        "@sanity/client": "^6.27.2",
+        "@sanity/cli": "3.77.1",
+        "@sanity/client": "^6.28.1",
         "@sanity/color": "^3.0.0",
         "@sanity/comlink": "^3.0.1",
-        "@sanity/diff": "3.74.1",
+        "@sanity/diff": "3.77.1",
         "@sanity/diff-match-patch": "^3.1.1",
+        "@sanity/diff-patch": "^5.0.0",
         "@sanity/eventsource": "^5.0.0",
         "@sanity/export": "^3.42.2",
-        "@sanity/icons": "^3.5.7",
+        "@sanity/icons": "^3.6.0",
         "@sanity/image-url": "^1.0.2",
         "@sanity/import": "^3.37.9",
-        "@sanity/insert-menu": "1.0.20",
+        "@sanity/insert-menu": "^1.1.3",
         "@sanity/logos": "^2.1.13",
-        "@sanity/migrate": "3.74.1",
-        "@sanity/mutator": "3.74.1",
-        "@sanity/presentation-comlink": "^1.0.4",
+        "@sanity/migrate": "3.77.1",
+        "@sanity/mutator": "3.77.1",
+        "@sanity/presentation-comlink": "^1.0.8",
         "@sanity/preview-url-secret": "^2.1.4",
-        "@sanity/schema": "3.74.1",
+        "@sanity/schema": "3.77.1",
         "@sanity/telemetry": "^0.7.7",
-        "@sanity/types": "3.74.1",
-        "@sanity/ui": "^2.11.8",
-        "@sanity/util": "3.74.1",
+        "@sanity/types": "3.77.1",
+        "@sanity/ui": "^2.14.3",
+        "@sanity/util": "3.77.1",
         "@sanity/uuid": "^3.0.2",
         "@sentry/react": "^8.33.0",
         "@tanstack/react-table": "^8.16.0",
@@ -22577,13 +22539,13 @@
         "pretty-ms": "^7.0.1",
         "quick-lru": "^5.1.1",
         "raf": "^3.4.1",
-        "react-compiler-runtime": "19.0.0-beta-714736e-20250131",
+        "react-compiler-runtime": "19.0.0-beta-e1e972c-20250221",
         "react-fast-compare": "^3.2.0",
         "react-focus-lock": "^2.13.5",
         "react-i18next": "14.0.2",
         "react-is": "^18.2.0",
         "react-refractor": "^2.1.6",
-        "react-rx": "^4.1.18",
+        "react-rx": "^4.1.21",
         "read-pkg-up": "^7.0.1",
         "refractor": "^3.6.0",
         "resolve-from": "^5.0.0",
@@ -22592,7 +22554,6 @@
         "rxjs": "^7.8.0",
         "rxjs-exhaustmap-with-trailing": "^2.1.1",
         "rxjs-mergemap-array": "^0.1.0",
-        "sanity-diff-patch": "^4.0.0",
         "scroll-into-view-if-needed": "^3.0.3",
         "semver": "^7.3.5",
         "shallow-equals": "^1.0.0",
@@ -22624,17 +22585,6 @@
     "node_modules/sanity-assist-test-studio": {
       "resolved": "studio",
       "link": true
-    },
-    "node_modules/sanity-diff-patch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/sanity-diff-patch/-/sanity-diff-patch-4.0.0.tgz",
-      "integrity": "sha512-1OOTx/Uw0J3rwNkI4J/4XJfTGb2Rze/gl5jJGRw+M2hRGkp1QEu2wFHiC9adj83ABYthOczBCBpTHHeZluctdw==",
-      "dependencies": {
-        "@sanity/diff-match-patch": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=18.2"
-      }
     },
     "node_modules/sanity-plugin-internationalized-array": {
       "version": "2.1.0",
@@ -23181,34 +23131,32 @@
       }
     },
     "node_modules/sanity/node_modules/@portabletext/block-tools": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-1.1.6.tgz",
-      "integrity": "sha512-u+eJpY/60vzKGDxus1UDOdZ7fRR42qQcFJcJaMHo0yyeRvp2Pz2/e5AEDhO45XDd2M2FSM8eSFqSGRiGgS3NhQ==",
-      "license": "MIT",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-1.1.9.tgz",
+      "integrity": "sha512-Yov1p6AKil/iPuGPrw89QpwbaCfwrLfFDcw7EgQnTfbWLH0N2uZRiVxMynXUfew7mH4Gq4VWnNxIdyfdmLN0Lg==",
       "dependencies": {
         "get-random-values-esm": "1.0.2",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "@sanity/types": "^3.74.1",
+        "@sanity/types": "^3.76.3",
         "@types/react": "18 || 19"
       }
     },
     "node_modules/sanity/node_modules/@portabletext/editor": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-1.31.0.tgz",
-      "integrity": "sha512-354MCNmqkrDAktcg4+h42IKDP2mLu/q48Vv7MvvNEQIwdSpqxkGzg8RsEw2IlkjXB4heJvpQKGi8e6Q9JdfPZg==",
-      "license": "MIT",
+      "version": "1.35.4",
+      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-1.35.4.tgz",
+      "integrity": "sha512-N+tfndK32AE5EA2cfwH9xY6nshXSnOdfQfNEX2tbx4UZZ0EEUzofXB9CqgK9XlrY2HbyKJefkWidfKIaXNny3w==",
       "dependencies": {
-        "@portabletext/block-tools": "1.1.6",
-        "@portabletext/patches": "1.1.2",
+        "@portabletext/block-tools": "1.1.9",
+        "@portabletext/patches": "1.1.3",
         "@portabletext/to-html": "^2.0.14",
         "@xstate/react": "^5.0.2",
         "debug": "^4.4.0",
         "get-random-values-esm": "^1.0.2",
         "lodash": "^4.17.21",
         "lodash.startcase": "^4.4.0",
-        "react-compiler-runtime": "19.0.0-beta-714736e-20250131",
+        "react-compiler-runtime": "19.0.0-beta-e1e972c-20250221",
         "slate": "0.112.0",
         "slate-dom": "^0.112.2",
         "slate-react": "0.112.1",
@@ -23219,17 +23167,16 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/schema": "^3.74.1",
-        "@sanity/types": "^3.74.1",
+        "@sanity/schema": "^3.76.3",
+        "@sanity/types": "^3.76.3",
         "react": "^16.9 || ^17 || ^18 || ^19",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.2"
       }
     },
     "node_modules/sanity/node_modules/@portabletext/editor/node_modules/slate-react": {
       "version": "0.112.1",
       "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.112.1.tgz",
       "integrity": "sha512-V9b+waxPweXqAkSQmKQ1afG4Me6nVQACPpxQtHPIX02N7MXa5f5WilYv+bKt7vKKw+IZC2F0Gjzhv5BekVgP/A==",
-      "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
         "direction": "^1.0.4",
@@ -23438,7 +23385,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23553,10 +23499,9 @@
       }
     },
     "node_modules/sanity/node_modules/react-compiler-runtime": {
-      "version": "19.0.0-beta-714736e-20250131",
-      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.0.0-beta-714736e-20250131.tgz",
-      "integrity": "sha512-RJQqbR2zIobjLZ242MRQlWlyxLDxw0fRxbniImHxSsBqHSf35vK8CsClA37MfO729M3n4jCIawI3BCdBHksOvA==",
-      "license": "MIT",
+      "version": "19.0.0-beta-e1e972c-20250221",
+      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.0.0-beta-e1e972c-20250221.tgz",
+      "integrity": "sha512-6nONLW+4zbfAt6mLG6SV73tKlZLJqmezqX0EF9ZKzab84Pje/4CMVs8QVw4OeRS+FFtPcfWU4fOK28nq7lM4Hg==",
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
       }
@@ -23600,17 +23545,15 @@
     "node_modules/sanity/node_modules/tiny-invariant": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
-      "license": "MIT"
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
     },
     "node_modules/sanity/node_modules/vite": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.0.tgz",
-      "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
-      "license": "MIT",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.1.tgz",
+      "integrity": "sha512-4GgM54XrwRfrOp297aIYspIti66k56v16ZnqHvrIM7mG+HjDlAwS7p+Srr7J6fGvEdOJ5JcQ/D9T7HhtdXDTzA==",
       "dependencies": {
         "esbuild": "^0.24.2",
-        "postcss": "^8.5.1",
+        "postcss": "^8.5.2",
         "rollup": "^4.30.1"
       },
       "bin": {
@@ -24105,7 +24048,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
       "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
-      "license": "MIT",
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
@@ -24114,7 +24056,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
       "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
-      "license": "MIT",
       "dependencies": {
         "commander": "^2.8.1"
       },
@@ -24126,8 +24067,7 @@
     "node_modules/seek-bzip/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/semantic-release": {
       "version": "23.1.1",
@@ -24558,7 +24498,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.2"
       },
@@ -24828,7 +24767,6 @@
       "version": "0.112.0",
       "resolved": "https://registry.npmjs.org/slate/-/slate-0.112.0.tgz",
       "integrity": "sha512-PRnfFgDA3tSop4OH47zu4M1R4Uuhm/AmASu29Qp7sGghVFb713kPBKEnSf1op7Lx/nCHkRlCa3ThfHtCBy+5Yw==",
-      "license": "MIT",
       "dependencies": {
         "immer": "^10.0.3",
         "is-plain-object": "^5.0.0",
@@ -24839,7 +24777,6 @@
       "version": "0.112.2",
       "resolved": "https://registry.npmjs.org/slate-dom/-/slate-dom-0.112.2.tgz",
       "integrity": "sha512-cozITMlpcBxrov854reM6+TooiHiqpfM/nZPrnjpN1wSiDsAQmYbWUyftC+jlwcpFj80vywfDHzlG6hXIc5h6A==",
-      "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
         "direction": "^1.0.4",
@@ -24857,7 +24794,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24865,14 +24801,12 @@
     "node_modules/slate-dom/node_modules/tiny-invariant": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
-      "license": "MIT"
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
     },
     "node_modules/slate/node_modules/immer": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
       "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -24882,7 +24816,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25373,7 +25306,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
-      "license": "MIT",
       "dependencies": {
         "is-natural-number": "^4.0.1"
       }
@@ -25899,8 +25831,7 @@
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "license": "MIT"
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -25975,8 +25906,7 @@
     "node_modules/to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-      "license": "MIT"
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -26089,7 +26019,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
       "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
-      "license": "MIT",
       "dependencies": {
         "json5": "^2.2.2",
         "minimist": "^1.2.6",
@@ -26108,7 +26037,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
@@ -26244,7 +26172,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/typeid-js/-/typeid-js-0.3.0.tgz",
       "integrity": "sha512-A1EmvIWG6xwYRfHuYUjPltHqteZ1EiDG+HOmbIYXeHUVztmnGrPIfU9KIK1QC30x59ko0r4JsMlwzsALCyiB3Q==",
-      "license": "Apache-2.0",
       "dependencies": {
         "uuidv7": "^0.4.4"
       }
@@ -26301,7 +26228,6 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
       "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-      "license": "MIT",
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -26317,7 +26243,6 @@
       "version": "5.28.5",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
       "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
-      "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -26429,10 +26354,9 @@
       }
     },
     "node_modules/universal-user-agent": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-      "license": "ISC"
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q=="
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -26579,7 +26503,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
       "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
-      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -26617,7 +26540,6 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/uuidv7/-/uuidv7-0.4.4.tgz",
       "integrity": "sha512-jjRGChg03uGp9f6wQYSO8qXkweJwRbA5WRuEQE8xLIiehIzIIi23qZSzsyvZPCPoFqkeLtZuz7Plt1LGukAInA==",
-      "license": "Apache-2.0",
       "bin": {
         "uuidv7": "cli.js"
       }
@@ -26647,9 +26569,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
-      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -26705,9 +26627,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.0.tgz",
-      "integrity": "sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -27132,16 +27054,16 @@
       }
     },
     "node_modules/vitest": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.0.tgz",
-      "integrity": "sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "1.6.0",
-        "@vitest/runner": "1.6.0",
-        "@vitest/snapshot": "1.6.0",
-        "@vitest/spy": "1.6.0",
-        "@vitest/utils": "1.6.0",
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
         "acorn-walk": "^8.3.2",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
@@ -27155,7 +27077,7 @@
         "tinybench": "^2.5.1",
         "tinypool": "^0.8.3",
         "vite": "^5.0.0",
-        "vite-node": "1.6.0",
+        "vite-node": "1.6.1",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -27170,8 +27092,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "1.6.0",
-        "@vitest/ui": "1.6.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -27666,7 +27588,6 @@
       "version": "5.19.2",
       "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.19.2.tgz",
       "integrity": "sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==",
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"
@@ -27909,7 +27830,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -27919,7 +27839,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
       "engines": {
         "node": "*"
       }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -591,6 +591,27 @@ defineType({
 
 **If your schema is not using either of these structures**, refer to the section on [Custom language fields](#custom-language-fields).
 
+#### Note on document schema depth
+By default, field level translations will own translate 6 "path-segments" deep.
+
+If this is not sufficient for your document types, use `maxPathDepth`:
+
+```ts
+assist({
+  translate: {
+    field: {
+      maxPathDepth: 12
+    },
+  },
+})
+```
+
+Depth is based on field path segments:
+- `title` has depth 1
+- `array[_key="no"].title` has depth 3
+
+Be careful not to set this too high in studios with recursive document schemas, as it could have negative impact on performance.
+
 ### Loading field languages
 
 Languages must be an array of objects with an id and title.
@@ -749,7 +770,7 @@ function translationOutputs(
 }
 ```
 
-### Full field translation configuration example
+[### Full field translation configuration example]()
 
 ```ts
 assist({

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -592,7 +592,11 @@ defineType({
 **If your schema is not using either of these structures**, refer to the section on [Custom language fields](#custom-language-fields).
 
 #### Note on document schema depth
-By default, field level translations will own translate 6 "path-segments" deep.
+By default, field level translations will translate 6 "path-segments" deep.
+
+Depth is based on field path segments like so:
+- `title` has depth 1
+- `array[_key="no"].title` has depth 3
 
 If this is not sufficient for your document types, use `maxPathDepth`:
 
@@ -606,11 +610,8 @@ assist({
 })
 ```
 
-Depth is based on field path segments:
-- `title` has depth 1
-- `array[_key="no"].title` has depth 3
-
 Be careful not to set this too high in studios with recursive document schemas, as it could have negative impact on performance.
+maxPathDepth is hard-capped to 50.
 
 ### Loading field languages
 

--- a/plugin/src/helpers/conditionalMembers.test.ts
+++ b/plugin/src/helpers/conditionalMembers.test.ts
@@ -226,4 +226,51 @@ describe('conditionalMembers', () => {
       },
     ])
   })
+
+  test('should respect max-depth', () => {
+    const docSchema: ObjectSchemaType = Schema.compile({
+      name: 'test',
+      types: [
+        defineType({
+          type: 'document',
+          name: 'article',
+          fields: [
+            {type: 'string', name: 'title', readOnly: () => false},
+            {
+              type: 'object',
+              name: 'object',
+              fields: [{type: 'string', name: 'title', readOnly: () => false}],
+            },
+          ],
+        }),
+      ],
+    }).get('article')
+
+    const docState = {
+      path: [],
+      schemaType: docSchema,
+      members: [
+        {
+          kind: 'field',
+          field: {path: [docSchema.fields[0].name], schemaType: docSchema.fields[0].type},
+        },
+        {
+          kind: 'field',
+          field: {
+            path: [docSchema.fields[1].name],
+            schemaType: docSchema.fields[1].type,
+            members: [
+              {
+                kind: 'field',
+                field: {path: ['object', 'title'], schemaType: docSchema.fields[0].type},
+              },
+            ],
+          },
+        },
+      ],
+    } as any
+    const conditionalMembers = getConditionalMembers(docState, 1)
+
+    expect(conditionalMembers).toEqual([{path: 'title', hidden: false, readOnly: false}])
+  })
 })

--- a/plugin/src/helpers/conditionalMembers.ts
+++ b/plugin/src/helpers/conditionalMembers.ts
@@ -12,7 +12,7 @@ import {
   type SchemaType,
 } from 'sanity'
 
-const MAX_DEPTH = 8
+const DEFAULT_MAX_DEPTH = 8
 
 export interface ConditionalMemberState {
   path: string
@@ -37,7 +37,10 @@ interface ConditionalMemberInnerState extends ConditionalMemberState {
  * * If a parent path is readOnly, no child paths are included
  * * If a path is hidden, it is not included; only conditionally visible paths will be returned, with hidden: false
  */
-export function getConditionalMembers(docState: DocumentFormNode): ConditionalMemberState[] {
+export function getConditionalMembers(
+  docState: DocumentFormNode,
+  maxDepth = DEFAULT_MAX_DEPTH,
+): ConditionalMemberState[] {
   const doc: ConditionalMemberInnerState = {
     path: '',
     hidden: false,
@@ -45,7 +48,7 @@ export function getConditionalMembers(docState: DocumentFormNode): ConditionalMe
     conditional: isConditional(docState.schemaType),
   }
   return (
-    [doc, ...extractConditionalPaths(docState, MAX_DEPTH)]
+    [doc, ...extractConditionalPaths(docState, maxDepth)]
       .filter((v) => v.conditional)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       .map(({conditional, ...state}) => ({...state}))

--- a/plugin/src/helpers/conditionalMembers.ts
+++ b/plugin/src/helpers/conditionalMembers.ts
@@ -13,6 +13,7 @@ import {
 } from 'sanity'
 
 const DEFAULT_MAX_DEPTH = 8
+const ABSOLUTE_MAX_DEPTH = 50
 
 export interface ConditionalMemberState {
   path: string
@@ -48,7 +49,7 @@ export function getConditionalMembers(
     conditional: isConditional(docState.schemaType),
   }
   return (
-    [doc, ...extractConditionalPaths(docState, maxDepth)]
+    [doc, ...extractConditionalPaths(docState, Math.min(maxDepth, ABSOLUTE_MAX_DEPTH))]
       .filter((v) => v.conditional)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       .map(({conditional, ...state}) => ({...state}))

--- a/plugin/src/translate/FieldTranslationProvider.tsx
+++ b/plugin/src/translate/FieldTranslationProvider.tsx
@@ -112,7 +112,7 @@ export function FieldTranslationProvider(props: PropsWithChildren<{}>) {
       setToLanguages(filteredToLanguages)
       const fromId = from?.id
       const allToIds = allToLanguages?.map((l) => l.id) ?? []
-      const docMembers = getDocumentMembersFlat(document, documentSchema)
+      const docMembers = getDocumentMembersFlat(document, documentSchema, config?.maxPathDepth)
       if (fromId && allToIds?.length) {
         const transMap = getFieldLanguageMap(
           documentSchema,

--- a/plugin/src/translate/paths.test.ts
+++ b/plugin/src/translate/paths.test.ts
@@ -137,4 +137,45 @@ describe('paths', () => {
       'translations[_key=="en"].value',
     ])
   })
+
+  test('should limit depth to 1 when specified', () => {
+    const docSchema: ObjectSchemaType = Schema.compile({
+      name: 'test',
+      types: [
+        defineType({
+          type: 'document',
+          name: 'article',
+          fields: [
+            {
+              type: 'array',
+              name: 'translations',
+              of: [
+                {
+                  type: 'object',
+                  name: 'internationalizedArrayString',
+                  fields: [{type: 'string', name: 'value'}],
+                },
+              ],
+            },
+          ],
+        }),
+      ],
+    }).get('article')
+
+    const doc: SanityDocumentLike = {
+      _id: 'na',
+      _type: 'article',
+      translations: [
+        {
+          //assume type is missing in the data for some reason
+          //_type: 'internationalizedArrayString',
+          _key: 'en',
+          value: 'some string',
+        },
+      ],
+    }
+
+    const members = getDocumentMembersFlat(doc, docSchema, 1)
+    expect(members.map((p) => pathToString(p.path))).toEqual(['translations'])
+  })
 })

--- a/plugin/src/translate/paths.ts
+++ b/plugin/src/translate/paths.ts
@@ -17,6 +17,7 @@ export interface FieldLanguageMap {
 }
 
 const DEFAULT_MAX_DEPTH = 6
+const ABSOLUTE_MAX_DEPTH = 50
 
 export function getDocumentMembersFlat(
   doc: SanityDocumentLike,
@@ -28,7 +29,7 @@ export function getDocumentMembersFlat(
     return []
   }
 
-  return extractPaths(doc, schemaType, [], maxDepth)
+  return extractPaths(doc, schemaType, [], Math.min(maxDepth, ABSOLUTE_MAX_DEPTH))
 }
 
 function extractPaths(
@@ -63,7 +64,9 @@ function extractPaths(
     } else if (
       fieldSchema.jsonType === 'array' &&
       fieldSchema.of.length &&
-      fieldSchema.of.some((item) => 'fields' in item)
+      fieldSchema.of.some((item) => 'fields' in item) &&
+      // no reason to drill into arrays if the item fields will be culled by maxDepth, ie we need 1 extra path headroom
+      path.length + 1 < maxDepth
     ) {
       const {value: arrayValue} = extractWithPath(pathToString(fieldPath), doc)[0] ?? {}
 

--- a/plugin/src/translate/paths.ts
+++ b/plugin/src/translate/paths.ts
@@ -16,15 +16,19 @@ export interface FieldLanguageMap {
   outputs: TranslationOutput[]
 }
 
-const MAX_DEPTH = 6
+const DEFAULT_MAX_DEPTH = 6
 
-export function getDocumentMembersFlat(doc: SanityDocumentLike, schemaType: ObjectSchemaType) {
+export function getDocumentMembersFlat(
+  doc: SanityDocumentLike,
+  schemaType: ObjectSchemaType,
+  maxDepth = DEFAULT_MAX_DEPTH,
+) {
   if (!isDocumentSchemaType(schemaType)) {
     console.error(`Schema type is not a document`)
     return []
   }
 
-  return extractPaths(doc, schemaType, [], MAX_DEPTH)
+  return extractPaths(doc, schemaType, [], maxDepth)
 }
 
 function extractPaths(

--- a/plugin/src/translate/translateActions.tsx
+++ b/plugin/src/translate/translateActions.tsx
@@ -123,6 +123,7 @@ export const translateActions: DocumentFieldAction = {
         task: fieldTranslate.openFieldTranslation,
       })
 
+      const maxDepth = config.translate?.field?.maxPathDepth
       const translateFieldsAction = useMemo(
         () =>
           fieldTransEnabled
@@ -148,7 +149,7 @@ export const translateActions: DocumentFieldAction = {
                     documentSchema: documentSchemaType,
                     translatePath: path,
                     conditionalMembers: formStateRef.current
-                      ? getConditionalMembers(formStateRef.current)
+                      ? getConditionalMembers(formStateRef.current, maxDepth)
                       : [],
                   })
                 },
@@ -164,6 +165,7 @@ export const translateActions: DocumentFieldAction = {
           fieldTransEnabled,
           path,
           readOnly,
+          maxDepth,
         ],
       )
 

--- a/plugin/src/translate/types.ts
+++ b/plugin/src/translate/types.ts
@@ -76,7 +76,6 @@ export interface FieldTranslationConfig {
    *
    *  It determines the relationships between document paths: Given a document path and a language, into which
    *  sibling paths should translations be output.
-
    *
    * `translationOutputs` is invoked once per path in the document (limited to a depth of 6), with the following:
    *
@@ -121,8 +120,24 @@ export interface FieldTranslationConfig {
    *   return undefined
    * }
    * ```
+   *
+   * @see #maxPathDepth
    **/
   translationOutputs?: TranslationOutputsFunction
+
+  /**
+   * The max depth for document paths AI Assist will translate.
+   *
+   * Depth is based on field path segments:
+   * - `title` has depth 1
+   * - `array[_key="no"].title` has depth 3
+   *
+   * Be careful not to set this too high in studios with recursive document schemas, as it could have
+   * negative impact on performance.
+   *
+   * Default: 6
+   */
+  maxPathDepth?: number
 }
 
 export interface DocumentTranslationConfig {

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
               setTimeout(() => resolve(languages), 500)
             })
           },
+          maxPathDepth: 12,
         },
         document: {
           documentTypes: translatedDocTypes,

--- a/studio/schemas/languageArticle.tsx
+++ b/studio/schemas/languageArticle.tsx
@@ -72,6 +72,30 @@ export const localeObject = defineType({
   options: {aiAssist: {translateAction: true}},
 })
 
+export const recursiveObject = defineType({
+  type: 'object',
+  name: 'recursiveObject',
+  title: 'Recursive',
+  fields: [
+    defineField({
+      type: 'array',
+      name: 'recursive',
+      title: 'Recursive array',
+      of: [{type: 'recursiveObject'}],
+    }),
+    defineField({
+      name: 'title',
+      type: 'internationalizedArrayString',
+      title: 'Title',
+    }),
+  ],
+  options: {
+    aiAssist: {
+      translateAction: true,
+    },
+  },
+})
+
 export const languageArticle = defineType({
   type: 'document',
   name: 'languageArticle',
@@ -134,6 +158,10 @@ export const languageArticle = defineType({
       name: 'alternateTitles',
       title: 'Alternate titles',
       of: [{type: 'string'}],
+    }),
+    defineField({
+      type: recursiveObject.name,
+      name: 'recursive',
     }),
     defineField({
       name: 'description',


### PR DESCRIPTION
New config param `maxPathDepth` for field translation config.

This allows devs to configure how deep into the document field translations will try to translate. This is depth limited

This is a client-side/plugin only fix.

The studio is configured with max depth 12.
This means that the i18n-array in the 5-th item will be translated:
`recurse[_key="item1"].recurse[_key="item3"].recurse[_key="item4"].recurse[_key="item5"].langArray[_key="en"].title`,
but not the sixth:
`recurse[_key="item1"].recurse[_key="item3"].recurse[_key="item4"].recurse[_key="item5"].recurse[_key="item6"].langArray[_key="en"].title`

## Testing
I deployed this branch, so it can be tested:
Scroll down to the "Recursive" field here: https://ai-poc-config.sanity.studio/structure/languageArticle;12407e4b-73e7-4c07-8b30-31e0558b7daa

Scroll down to the "Recursive" object

![image](https://github.com/user-attachments/assets/8fdb671a-96ba-4590-b8ba-f6fc13b0263b)

Run the translate action for the field, select one or more languages to translate from English.
Click into the arrays, and verify that there is translate things at level 5, but not at level 6.


