### PR TITLE
feat: translate styleguide can now be an async function

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -915,6 +915,21 @@ the plugin will throw upon studio startup.
 Note that this is currently only available on a global level - it can not be defined
 per-field for now.
 
+### Dynamic styleguide
+
+As of 4.1.0 it is also possible to provide a styleguide async function.
+The function is passed a context object with Sanity client and the current documentId and schemaType. 
+
+Consider caching the results: the function is invoked every time translate runs.
+
+```ts
+assist({
+  translate: {
+    styleguide: ({client, documentId, schemaType}) => client.fetch('* [_id=="styleguide.singleton"][0].styleguide')
+  },
+})
+```
+
 ## Caveats
 
 Large Language Models (LLMs) are a new technology. Constraints and limitations are still being explored,

--- a/plugin/src/helpers/styleguide.ts
+++ b/plugin/src/helpers/styleguide.ts
@@ -2,7 +2,7 @@ import {packageName} from '../constants'
 import {TranslateStyleguide, TranslateStyleguideContext} from '../translate/types'
 
 export function validateStyleguide(styleguide: string | undefined) {
-  if (styleguide && styleguide?.length > 2000) {
+  if (styleguide && styleguide.length > 2000) {
     throw new Error(
       `[${packageName}]: \`translate.styleguide\` value is too long. It must be 2000 characters or less, but was ${styleguide.length} characters`,
     )

--- a/plugin/src/helpers/styleguide.ts
+++ b/plugin/src/helpers/styleguide.ts
@@ -1,0 +1,24 @@
+import {packageName} from '../constants'
+import {TranslateStyleguide, TranslateStyleguideContext} from '../translate/types'
+
+export function validateStyleguide(styleguide: string) {
+  if (styleguide.length > 2000) {
+    throw new Error(
+      `[${packageName}]: \`translate.styleguide\` value is too long. It must be 2000 characters or less, but was ${styleguide.length} characters`,
+    )
+  }
+}
+
+export function createStyleGuideResolver(
+  styleguide: TranslateStyleguide | undefined,
+  context: TranslateStyleguideContext,
+) {
+  return async () => {
+    if (typeof styleguide !== 'function') {
+      return styleguide
+    }
+    const styleguideResult = await styleguide(context)
+    validateStyleguide(styleguideResult)
+    return styleguideResult
+  }
+}

--- a/plugin/src/helpers/styleguide.ts
+++ b/plugin/src/helpers/styleguide.ts
@@ -1,12 +1,13 @@
 import {packageName} from '../constants'
 import {TranslateStyleguide, TranslateStyleguideContext} from '../translate/types'
 
-export function validateStyleguide(styleguide: string) {
-  if (styleguide.length > 2000) {
+export function validateStyleguide(styleguide: string | undefined) {
+  if (styleguide && styleguide?.length > 2000) {
     throw new Error(
       `[${packageName}]: \`translate.styleguide\` value is too long. It must be 2000 characters or less, but was ${styleguide.length} characters`,
     )
   }
+  return styleguide
 }
 
 export function createStyleGuideResolver(
@@ -18,7 +19,6 @@ export function createStyleGuideResolver(
       return styleguide
     }
     const styleguideResult = await styleguide(context)
-    validateStyleguide(styleguideResult)
-    return styleguideResult
+    return validateStyleguide(styleguideResult)
   }
 }

--- a/plugin/src/plugin.tsx
+++ b/plugin/src/plugin.tsx
@@ -9,17 +9,18 @@ import {AssistInlineFormBlock} from './assistFormComponents/AssistInlineFormBloc
 import {AssistItem} from './assistFormComponents/AssistItem'
 import {assistInspector} from './assistInspector'
 import {AssistLayout} from './assistLayout/AssistLayout'
+import {AssistConfig} from './assistTypes'
 import {ImageContextProvider} from './components/ImageContext'
 import {SafeValueInput} from './components/SafeValueInput'
 import {packageName} from './constants'
 import {assistFieldActions} from './fieldActions/assistFieldActions'
 import {isSchemaAssistEnabled} from './helpers/assistSupported'
+import {validateStyleguide} from './helpers/styleguide'
 import {isImage} from './helpers/typeUtils'
 import {createAssistDocumentPresence} from './presence/AssistDocumentPresence'
 import {schemaTypes} from './schemas'
 import {TranslationConfig} from './translate/types'
 import {assistDocumentTypeName, AssistPreset} from './types'
-import {AssistConfig} from './assistTypes'
 
 export interface AssistPluginConfig {
   translate?: TranslationConfig
@@ -46,10 +47,8 @@ export const assist = definePlugin<AssistPluginConfig | void>((config) => {
   const maxPathDepth = configWithDefaults.assist?.maxPathDepth
   const temperature = configWithDefaults.assist?.temperature
 
-  if (styleguide.length > 2000) {
-    throw new Error(
-      `[${packageName}]: \`translate.styleguide\` value is too long. It must be 2000 characters or less, was ${styleguide.length} characters`,
-    )
+  if (typeof styleguide === 'string') {
+    validateStyleguide(styleguide)
   }
 
   if (maxPathDepth !== undefined && (maxPathDepth < 1 || maxPathDepth > 12)) {

--- a/plugin/src/translate/types.ts
+++ b/plugin/src/translate/types.ts
@@ -1,4 +1,4 @@
-import {Path, SanityClient, SchemaType} from 'sanity'
+import {ObjectSchemaType, Path, SanityClient, SchemaType} from 'sanity'
 
 export interface Language {
   id: string
@@ -163,6 +163,20 @@ export interface DocumentTranslationConfig {
   documentTypes?: string[]
 }
 
+export interface TranslateStyleguideContext {
+  documentId: string
+  schemaType: ObjectSchemaType
+  client: SanityClient
+  /**
+   * Only provided for field translations
+   */
+  translatePath?: Path
+}
+
+export type TranslateStyleguide =
+  | string
+  | ((context: TranslateStyleguideContext) => Promise<string>)
+
 export interface TranslationConfig {
   /**
    * Config for document types with fields in multiple languages in the same document.
@@ -176,6 +190,8 @@ export interface TranslationConfig {
    * A "style guide" that can be used to provide guidance on how to translate content.
    * Will be passed to the LLM - ergo this is only a guide and the model _may_ not
    * always follow it to the letter.
+   *
+   * When providing a function, consider caching the results of any async operation; it will invoked every time translate runs
    */
-  styleguide?: string
+  styleguide?: TranslateStyleguide
 }

--- a/plugin/src/useApiClient.ts
+++ b/plugin/src/useApiClient.ts
@@ -35,13 +35,13 @@ export interface TranslateRequest {
   documentId: string
   translatePath: Path
   languagePath?: string
-  styleguide?: string
+  styleguide: () => Promise<string | undefined>
   fieldLanguageMap?: FieldLanguageMap[]
   conditionalMembers?: ConditionalMemberState[]
 }
 
 const basePath = '/assist/tasks/instruction'
-const API_VERSION_WITH_EXTENDED_TYPES = '2025-04-01'
+export const API_VERSION_WITH_EXTENDED_TYPES = '2025-04-01'
 
 export function canUseAssist(status: InstructStatus | undefined) {
   return status?.enabled && status.initialized && status.validToken
@@ -73,8 +73,8 @@ export function useTranslate(apiClient: SanityClient) {
     }: TranslateRequest) => {
       setLoading(true)
 
-      return apiClient
-        .request({
+      async function run() {
+        return apiClient.request({
           method: 'POST',
           url: `/assist/tasks/translate/${apiClient.config().dataset}?projectId=${
             apiClient.config().projectId
@@ -83,7 +83,7 @@ export function useTranslate(apiClient: SanityClient) {
             documentId,
             types,
             languagePath,
-            userStyleguide: styleguide,
+            userStyleguide: await styleguide(),
             fieldLanguageMap,
             conditionalMembers,
             translatePath:
@@ -91,6 +91,9 @@ export function useTranslate(apiClient: SanityClient) {
             userId: user?.id,
           },
         })
+      }
+
+      return run()
         .catch((e) => {
           toast.push({
             status: 'error',

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -73,7 +73,11 @@ export default defineConfig({
           documentTypes: translatedDocTypes,
           languageField: 'language',
         },
-        styleguide: 'Retain the word "Headless" in all translations as is, regardless of language.',
+        styleguide: () => {
+          return Promise.resolve(
+            'Retain the word "Headless" in all translations as is, regardless of language.',
+          )
+        },
       },
 
       __customApiClient: (defaultClient) =>


### PR DESCRIPTION
Makes styleguide dynamic.

See readme for usage.

## Testing

* Create a new article: https://ai-assist-test.sanity.studio/structure/mockArticle
* The word "headless" is set to not be translated.
* Populate the document with some content and check that "headless" is not translated when running document translation

--

* Create a new field translation doc: https://ai-assist-test.sanity.studio/structure/languageArticle
* Same styleguide
* Populate the document with some content and check that "headless" is not translated when running document translation from the document menu, or from a field.