### PR TITLE
feat: imageDescriptionField can now be configured to NOT update whenever the asset changes

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -407,6 +407,16 @@ The **Generate image description** action will automatically run whenever the im
 `imageDescriptionField` can be a nested field, if the image has an object field, i.e. `imageDescriptionField: 'wrapper.altText'`.
 Fields within array items are not supported.
 
+By default, the caption field will regenerate whenever the image asset changes. To disable this behavior use the following configuration:
+```ts
+{
+  imageDescriptionField: {
+    path: 'wrapper.altText',
+      updateOnImageChange: false
+  }
+}
+```
+
 ## Image generation
 
 <img width="600" alt="image" src="https://github.com/sanity-io/assist/assets/835514/c4de6791-f530-4cd1-b0c2-96ef988bc256">

--- a/plugin/src/components/ImageContext.tsx
+++ b/plugin/src/components/ImageContext.tsx
@@ -40,7 +40,7 @@ export function ImageContextProvider(props: InputProps) {
     if (
       assetRef &&
       assistableDocumentId &&
-      descriptionField &&
+      descriptionField?.updateOnImageChange &&
       assetRef !== assetRefState &&
       !isSyncing &&
       !isShowingOlderRevision &&
@@ -49,7 +49,7 @@ export function ImageContextProvider(props: InputProps) {
       setAssetRefState(assetRef)
       if (canUseAssist(status)) {
         generateCaption({
-          path: pathToString([...path, descriptionField]),
+          path: pathToString([...path, descriptionField.path]),
           documentId: assistableDocumentId,
         })
       }
@@ -71,8 +71,8 @@ export function ImageContextProvider(props: InputProps) {
     const descriptionField = getDescriptionFieldOption(schemaType)
     const imageInstructionField = getImageInstructionFieldOption(schemaType)
     return {
-      imageDescriptionPath: descriptionField
-        ? pathToString([...path, descriptionField])
+      imageDescriptionPath: descriptionField?.path
+        ? pathToString([...path, descriptionField.path])
         : undefined,
       imageInstructionPath: imageInstructionField
         ? pathToString([...path, imageInstructionField])

--- a/plugin/src/helpers/typeUtils.ts
+++ b/plugin/src/helpers/typeUtils.ts
@@ -18,13 +18,23 @@ export function isImage(schemaType: SchemaType) {
   return isType(schemaType, 'image')
 }
 
-export function getDescriptionFieldOption(schemaType: SchemaType | undefined): string | undefined {
+export function getDescriptionFieldOption(
+  schemaType: SchemaType | undefined,
+): {path: string; updateOnImageChange: boolean} | undefined {
   if (!schemaType) {
     return undefined
   }
   const descriptionField = (schemaType.options as ImageOptions)?.aiAssist?.imageDescriptionField
-  if (descriptionField) {
-    return descriptionField
+  if (typeof descriptionField === 'string') {
+    return {
+      path: descriptionField,
+      updateOnImageChange: true,
+    }
+  } else if (descriptionField) {
+    return {
+      path: descriptionField.path,
+      updateOnImageChange: descriptionField.updateOnImageChange ?? true,
+    }
   }
   return getDescriptionFieldOption(schemaType.type)
 }

--- a/plugin/src/schemas/typeDefExtensions.ts
+++ b/plugin/src/schemas/typeDefExtensions.ts
@@ -90,7 +90,18 @@ declare module 'sanity' {
        * })
        * ```
        */
-      imageDescriptionField?: string
+      imageDescriptionField?:
+        | string
+        | {
+            path: string
+            /**
+             * When updateOnImageChange is true (or undefined), whenever the
+             * image asset changes, imageDescriptionField will be regenerated.
+             *
+             * default:  true
+             * */
+            updateOnImageChange?: boolean
+          }
     }
   }
   interface NumberOptions extends AssistOptions {}

--- a/studio/schemas/mockArticle.tsx
+++ b/studio/schemas/mockArticle.tsx
@@ -621,7 +621,10 @@ export const mockArticle = defineType({
       ],
       options: {
         aiAssist: {
-          imageDescriptionField: 'wrapper.wrapper.caption',
+          imageDescriptionField: {
+            path: 'wrapper.wrapper.caption',
+            updateOnImageChange: false,
+          },
         },
       },
     }),


### PR DESCRIPTION
See the readme change.

## Testing

Change the asset on the Conver image here:
https://ai-assist-test.sanity.studio/structure/mockArticle;38994620-8e19-4f85-a88a-7f9d0caba7c5
It should update the caption.

Next, change the asset of the "Image (inline type)" below.
It should NOT update the caption

In both places the caption field for each image should still have "Generate image description" action
![image](https://github.com/user-attachments/assets/9b2ad09c-f6f7-4ecd-93a8-6b2294ba0ed5)
