### PR TITLE
feat: useFieldActions now receive parentSchemaType as a prop when available

### DIFF
--- a/plugin/src/assistDocument/AssistDocumentContext.tsx
+++ b/plugin/src/assistDocument/AssistDocumentContext.tsx
@@ -2,6 +2,7 @@ import {createContext, useContext} from 'react'
 import {DocumentInspector, ObjectSchemaType, PatchEvent} from 'sanity'
 
 import {InstructionTask, StudioAssistDocument} from '../types'
+import {FieldRef} from '../assistInspector/helpers'
 
 export type AssistDocumentContextValue = (
   | {assistDocument: StudioAssistDocument; loading: false}
@@ -32,6 +33,9 @@ export type AssistDocumentContextValue = (
   syntheticTasks?: InstructionTask[]
   addSyntheticTask: (syntheticTask: InstructionTask) => void
   removeSyntheticTask: (syntheticTask: InstructionTask) => void
+
+  fieldRefs: FieldRef[]
+  fieldRefsByTypePath: Record<string, FieldRef | undefined>
 }
 
 export const AssistDocumentContext = createContext<AssistDocumentContextValue | undefined>(

--- a/plugin/src/assistDocument/hooks/useAssistDocumentContextValue.tsx
+++ b/plugin/src/assistDocument/hooks/useAssistDocumentContextValue.tsx
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useMemo, useState} from 'react'
 import {getDraftId, getVersionId, type ObjectSchemaType, useSchema} from 'sanity'
 import {useDocumentPane} from 'sanity/structure'
 
-import {useAiPaneRouter} from '../../assistInspector/helpers'
+import {asFieldRefsByTypePath, getFieldRefs, useAiPaneRouter} from '../../assistInspector/helpers'
 import {fieldPathParam, InstructionTask} from '../../types'
 import type {AssistDocumentContextValue} from '../AssistDocumentContext'
 import {isDocAssistable} from '../RequestRunInstructionProvider'
@@ -53,6 +53,10 @@ export function useAssistDocumentContextValue(documentId: string, documentType: 
   })
   const {syntheticTasks, addSyntheticTask, removeSyntheticTask} =
     useSyntheticTasks(assistableDocumentId)
+
+  const fieldRefs = getFieldRefs(documentSchemaType)
+  const fieldRefsByTypePath = asFieldRefsByTypePath(fieldRefs)
+
   const value: AssistDocumentContextValue = useMemo(() => {
     const base = {
       assistableDocumentId,
@@ -67,6 +71,8 @@ export function useAssistDocumentContextValue(documentId: string, documentType: 
       syntheticTasks,
       addSyntheticTask,
       removeSyntheticTask,
+      fieldRefs,
+      fieldRefsByTypePath,
     }
     if (!assistDocument) {
       return {...base, loading: true, assistDocument: undefined}

--- a/plugin/src/assistInspector/helpers.ts
+++ b/plugin/src/assistInspector/helpers.ts
@@ -57,6 +57,14 @@ export function getTypeIcon(schemaType: SchemaType) {
   return DocumentIcon
 }
 
+export function asFieldRefsByTypePath(fieldRefs: FieldRef[]): Record<string, FieldRef | undefined> {
+  const lookup: Record<string, FieldRef | undefined> = fieldRefs.reduce(
+    (acc, ref) => ({...acc, [ref.key]: ref}),
+    {},
+  )
+  return lookup
+}
+
 export function getFieldRefsWithDocument(schemaType: ObjectSchemaType): FieldRef[] {
   const fields = getFieldRefs(schemaType)
   return [

--- a/plugin/src/fieldActions/assistFieldActions.tsx
+++ b/plugin/src/fieldActions/assistFieldActions.tsx
@@ -4,6 +4,7 @@ import {
   type DocumentFieldAction,
   type DocumentFieldActionGroup,
   type DocumentFieldActionItem,
+  pathToString,
   stringToPath,
   typed,
   useCurrentUser,
@@ -14,7 +15,7 @@ import {useAssistDocumentContext} from '../assistDocument/AssistDocumentContext'
 import {getIcon} from '../assistDocument/components/instruction/appearance/IconInput'
 import {useRequestRunInstruction} from '../assistDocument/RequestRunInstructionProvider'
 import {aiInspectorId} from '../assistInspector/constants'
-import {useSelectedField, useTypePath} from '../assistInspector/helpers'
+import {getTypePath, useSelectedField, useTypePath} from '../assistInspector/helpers'
 import {pluginTitleShort} from '../constants'
 import {isSchemaAssistEnabled} from '../helpers/assistSupported'
 import {getConditionalMembers} from '../helpers/conditionalMembers'
@@ -48,6 +49,7 @@ export const assistFieldActions: DocumentFieldAction = {
       documentSchemaType,
       selectedPath,
       assistableDocumentId,
+      fieldRefsByTypePath,
     } = useAssistDocumentContext()
 
     const {value: docValue, formState} = useDocumentPane()
@@ -204,6 +206,17 @@ export const assistFieldActions: DocumentFieldAction = {
       )
     }, [])
 
+    const parentSchemaType = useMemo(() => {
+      if (!props.path.length) {
+        return undefined
+      } else if (props.path.length === 1) {
+        return documentSchemaType
+      }
+      const parentPath = props.path.slice(0, -1)
+      const typePath = getTypePath(docValueRef.current, pathToString(parentPath))
+      return typePath ? fieldRefsByTypePath[typePath]?.schemaType : undefined
+    }, [fieldRefsByTypePath, props.path, documentSchemaType])
+
     const customActions = useCustomFieldActions({
       actionType: props.path.length ? 'field' : 'document',
       documentIdForAction: assistableDocumentId,
@@ -212,6 +225,7 @@ export const assistFieldActions: DocumentFieldAction = {
       path: props.path,
       getDocumentValue,
       getConditionalPaths,
+      parentSchemaType,
     })
 
     const manageInstructionsItem = useMemo(

--- a/plugin/src/fieldActions/customFieldActions.tsx
+++ b/plugin/src/fieldActions/customFieldActions.tsx
@@ -142,6 +142,16 @@ export interface AssistFieldActionProps {
    * ```
    */
   schemaType: SchemaType
+
+  /**
+   * Schema type of the parent field or array item holding this field.
+   *
+   * This can be undefined if the action was unable to resolve the parent type is excluded from AI Assist.
+   *
+   * @see schemaType
+   * @see documentSchemaType
+   */
+  parentSchemaType?: SchemaType
 }
 
 export type AssistFieldActionNode =


### PR DESCRIPTION
Makes `parentSchemaType` available to custom actions. This should simplify certain usecases, like checking if a field is inside an image object, for instance.