### PR TITLE
fix: assist actions are now enabled for images without custom fieldsto allow attaching custom actions

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1000,7 +1000,7 @@ prop can be used to parameterize Agent Actions on sanity client.
 #### Agent Action examples
 
 Below are some examples of agent action integration.
-For more, see [HOW-TO_USE](../studio/examples/agentActions/HOW-TO-USE.md)
+For more, see [HOW-TO-USE](../studio/examples/agentActions/HOW-TO-USE.md)
 
 ##### Fix spelling
 

--- a/plugin/src/helpers/assistSupported.ts
+++ b/plugin/src/helpers/assistSupported.ts
@@ -23,7 +23,11 @@ export function isAssistSupported(type: SchemaType) {
 
   if (type.jsonType === 'object') {
     const unsupportedObject = type.fields.every((field) => isDisabled(field.type))
-    return !unsupportedObject
+    return (
+      !unsupportedObject ||
+      /* to allow attaching custom actions on fieldless images */
+      isType(type, 'image')
+    )
   }
   return true
 }

--- a/plugin/src/schemas/serialize/serializeSchema.test.ts
+++ b/plugin/src/schemas/serialize/serializeSchema.test.ts
@@ -123,7 +123,7 @@ describe('serializeSchema', () => {
     expect(serializedTypes).toEqual([])
   })
 
-  test('should not serialize excluded fields or types or types with every member excluded', () => {
+  test('should not serialize excluded fields or types or types with every member excluded (except images)', () => {
     const options: AssistOptions = {aiAssist: {exclude: true}}
 
     const schema = Schema.compile({
@@ -131,7 +131,7 @@ describe('serializeSchema', () => {
       types: [
         {
           type: 'document',
-          name: 'allFieldsExcluded',
+          name: 'mostFieldsExcluded',
           fields: [
             defineField({type: 'string', name: 'title', options}),
             defineField({
@@ -148,7 +148,7 @@ describe('serializeSchema', () => {
               of: [{type: 'object', name: 'remove', options}, {type: 'excluded'}],
               options: {aiAssist: {exclude: true}},
             }),
-            //image without extra fields should be excluded
+            //image without extra fields should NOT be excluded
             defineField({type: 'image', name: 'image'}),
             defineField({type: 'file', name: 'file'}),
             defineField({type: 'reference', name: 'reference', to: [{type: 'excluded'}]}),
@@ -174,7 +174,21 @@ describe('serializeSchema', () => {
     const serializedTypes = serializeSchema(schema, {leanFormat: true})
 
     //everything excluded directly or indirectly
-    expect(serializedTypes).toEqual([])
+    expect(serializedTypes).toEqual([
+      {
+        fields: [
+          {
+            fields: [],
+            name: 'image',
+            title: 'Image',
+            type: 'image',
+          },
+        ],
+        name: 'mostFieldsExcluded',
+        title: 'Most Fields Excluded',
+        type: 'document',
+      },
+    ])
   })
 
   test('should serialize opt-in inline object using custom typeName', () => {

--- a/studio/examples/agentActions/HOW-TO-USE.md
+++ b/studio/examples/agentActions/HOW-TO-USE.md
@@ -25,7 +25,7 @@ See the TSDocs of each example action.
   - [Image description (configure by field name)](transform/imageDescriptionWithFieldName.ts) – Adds a image description action to image fields with `alt` or `description` in their field name.
   - [Image description (configure by options)](transform/imageDescriptionWithOptions.ts) – Adds a image description action to fields with `options.addImageDescriptionAction`.
   - [Replace words or phrases](transform/replacePhrase.ts) – Replace words or phrases on the current document or field (and any nested fields / array items)
-  - [Transform image](transform/fixSpelling.ts) – uses `useUserInput` to get how the image should be transformed
+  - [Transform image](transform/transformImage.ts) – uses `useUserInput` to get how the image should be transformed
 - [Translate](https://github.com/sanity-io/client?tab=readme-ov-file#translating-documents) examples
   - [Translate to any language](translate/translateToAny.ts) – uses `useUserInput` to get the language to translate to
 - [Prompt](https://github.com/sanity-io/client?tab=readme-ov-file#prompt-the-llm) examples

--- a/studio/schemas/mockArticle.tsx
+++ b/studio/schemas/mockArticle.tsx
@@ -374,6 +374,11 @@ export const mockArticle = defineType({
       },
     }),
     defineField({
+      type: 'image',
+      name: 'fieldlessImage',
+      title: 'Just an image',
+    }),
+    defineField({
       type: 'reference',
       name: 'category',
       title: 'Category',


### PR DESCRIPTION

### Description

We now show the AI Assist field action icon on images without custom fields. This is primarily to allow custom actions.

![image](https://github.com/user-attachments/assets/7b726534-4551-45a2-961e-c2cf595b4a72)

Also fixed a broken link.

### Testing

https://ai-assist-test.sanity.studio/structure/mockArticle

There is a new "Just an image" field in mockArticle. It should have Assist actions.

Note that some of the example actions probably should ideally not show up on field-less images, but I leave that to custom action implementors to solve as needed.
