### PR TITLE
fix(docs): Fixes typo in `inferAction` description

### DIFF
--- a/studio/examples/agentActions/HOW-TO-USE.md
+++ b/studio/examples/agentActions/HOW-TO-USE.md
@@ -30,4 +30,4 @@ See the TSDocs of each example action.
   - [Translate to any language](translate/translateToAny.ts) – uses `useUserInput` to get the language to translate to
 - [Prompt](https://github.com/sanity-io/client?tab=readme-ov-file#prompt-the-llm) examples
   - [Answer question](prompt/answerQuestion.tsx) – document action where the user can ask questions about the document
-  - [Infer action](prompt/inferAction.ts) – uses `useUserImput` to get a prompt to run, infers which action to run (generate or transform) and then runs it
+  - [Infer action](prompt/inferAction.ts) – uses `useUserInput` to get a prompt to run, infers which action to run (generate or transform) and then runs it


### PR DESCRIPTION
Fixes the typo used in the `inferAction` description in the `Agent Actions` [Readme](https://github.com/sanity-io/assist/blob/main/studio/examples/agentActions/HOW-TO-USE.md?plain=1#L33)

### Description

Minor typo used describing InferAction. `useUserImput` instead of `useUserInput`.

### What to review

Check proposed spelling is correct.
