### PR TITLE
fix: show array member error as a fallback if fields array is corrupted

### DIFF
--- a/plugin/src/assistDocument/components/AssistDocumentForm.tsx
+++ b/plugin/src/assistDocument/components/AssistDocumentForm.tsx
@@ -1,11 +1,13 @@
 import {Card, Stack, Text} from '@sanity/ui'
 import {useContext, useEffect, useMemo, useRef} from 'react'
 import {
+  FieldError,
   FormCallbacksProvider,
   FormCallbacksValue,
   FormInput,
   insert,
   KeyedSegment,
+  MemberFieldError,
   ObjectInputProps,
   ObjectSchemaType,
   PatchEvent,
@@ -127,6 +129,16 @@ function AssistDocumentFormEditable(props: ObjectInputProps) {
     }
   }, [activePath, instruction, onPathOpen])
 
+  const fieldError = useMemo(() => {
+    const fieldError = props.members.find(
+      (m): m is FieldError => m.kind === 'error' && m.fieldName === 'fields',
+    )
+    if (fieldError) {
+      return <MemberFieldError member={fieldError} />
+    }
+    return undefined
+  }, [props.members])
+
   return (
     <SelectedFieldContextProvider value={context}>
       <Stack space={5}>
@@ -140,13 +152,15 @@ function AssistDocumentFormEditable(props: ObjectInputProps) {
         />
         {instruction && <BackToInstructionListLink />}
 
-        {activePath && (
+        {activePath && !fieldError && (
           <FormCallbacksProvider {...newCallbacks}>
             <div style={{lineHeight: '1.25em'}}>
               <FormInput {...props} absolutePath={activePath} />
             </div>
           </FormCallbacksProvider>
         )}
+
+        {fieldError}
 
         {!activePath && props.renderDefault(props)}
       </Stack>


### PR DESCRIPTION
### Description

I suspect there might be a possibly race-condtion that sometimes results in duplicate keys in the `fields` array where AI Assist stores instruction during initialization. I have not tracked down the source of this error.

This is a best effort quickfix that will allow editors to fix their fields arrays using the standard "array error" component fron `sanity`.

Keys in this `fields` array carry semantic state, so "fixing the key by making it random" is not ideal here, but I suspect this only happens during init (so two empty field entries are added), which will leave the first entry unchanged, then leave a second, unreachable field entry. I think this is ok as a workaround.

Ideally we would autofix this/merge arrays, but that wont happen now.

The TLDR is that editors _has_ a recourse (see before & after) with this fix. 

## Before
<img width="500" height="168" alt="image" src="https://github.com/user-attachments/assets/6cd70b22-6e67-4574-8806-a32793da91e7" />

## After
<img width="569" height="453" alt="image" src="https://github.com/user-attachments/assets/1f3828d5-469e-48c0-879e-9d5b454f9fa4" />

(This will also handle missing keys and some other things).

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

I've tested this by forcefully patching in duplicates, then restoring. It works as we want: instruction array is accessible again.