### PR TITLE
fix: improves performance when rendering ai assisted fields

### DIFF
--- a/plugin/src/assistDocument/AssistDocumentContext.tsx
+++ b/plugin/src/assistDocument/AssistDocumentContext.tsx
@@ -1,7 +1,7 @@
 import {createContext, useContext} from 'react'
 import {DocumentInspector, ObjectSchemaType, PatchEvent} from 'sanity'
 
-import {InstructionTask, StudioAssistDocument} from '../types'
+import {InstructionTask, SerializedSchemaType, StudioAssistDocument} from '../types'
 import {FieldRef} from '../assistInspector/helpers'
 
 export type AssistDocumentContextValue = (
@@ -36,6 +36,8 @@ export type AssistDocumentContextValue = (
 
   fieldRefs: FieldRef[]
   fieldRefsByTypePath: Record<string, FieldRef | undefined>
+
+  serializedTypes: SerializedSchemaType[]
 }
 
 export const AssistDocumentContext = createContext<AssistDocumentContextValue | undefined>(

--- a/plugin/src/assistDocument/hooks/useAssistDocumentContextValue.tsx
+++ b/plugin/src/assistDocument/hooks/useAssistDocumentContextValue.tsx
@@ -4,9 +4,14 @@ import {useDocumentPane} from 'sanity/structure'
 
 import {asFieldRefsByTypePath, getFieldRefs, useAiPaneRouter} from '../../assistInspector/helpers'
 import {fieldPathParam, InstructionTask} from '../../types'
-import type {AssistDocumentContextValue} from '../AssistDocumentContext'
+import {AssistDocumentContextValue, useAssistDocumentContext} from '../AssistDocumentContext'
 import {isDocAssistable} from '../RequestRunInstructionProvider'
 import {useStudioAssistDocument} from './useStudioAssistDocument'
+import {serializeSchema} from '../../schemas/serialize/serializeSchema'
+
+export function useSerializedTypes() {
+  return useAssistDocumentContext().serializedTypes
+}
 
 export function useAssistDocumentContextValue(documentId: string, documentType: string) {
   const schema = useSchema()
@@ -18,6 +23,8 @@ export function useAssistDocumentContextValue(documentId: string, documentType: 
     }
     return schemaType
   }, [documentType, schema])
+
+  const serializedTypes = useMemo(() => serializeSchema(schema, {leanFormat: true}), [schema])
 
   const {fieldRefs, fieldRefsByTypePath} = useMemo(() => {
     const fieldRefs = getFieldRefs(documentSchemaType)
@@ -79,6 +86,7 @@ export function useAssistDocumentContextValue(documentId: string, documentType: 
       removeSyntheticTask,
       fieldRefs,
       fieldRefsByTypePath,
+      serializedTypes,
     }
     if (!assistDocument) {
       return {...base, loading: true, assistDocument: undefined}
@@ -104,6 +112,7 @@ export function useAssistDocumentContextValue(documentId: string, documentType: 
     removeSyntheticTask,
     fieldRefs,
     fieldRefsByTypePath,
+    serializedTypes,
   ])
 
   return value

--- a/plugin/src/useApiClient.ts
+++ b/plugin/src/useApiClient.ts
@@ -1,13 +1,13 @@
 import type {SanityClient} from '@sanity/client'
 import {useToast} from '@sanity/ui'
 import {useCallback, useMemo, useState} from 'react'
-import {Path, pathToString, useClient, useCurrentUser, useSchema} from 'sanity'
+import {Path, pathToString, useClient, useCurrentUser} from 'sanity'
 
 import {useAiAssistanceConfig} from './assistLayout/AiAssistanceConfigContext'
 import {ConditionalMemberState} from './helpers/conditionalMembers'
-import {serializeSchema} from './schemas/serialize/serializeSchema'
 import {FieldLanguageMap} from './translate/paths'
 import {documentRootKey} from './types'
+import {useSerializedTypes} from './assistDocument/hooks/useAssistDocumentContextValue'
 
 export interface UserTextInstance {
   blockKey: string
@@ -58,8 +58,7 @@ export function useApiClient(customApiClient?: (defaultClient: SanityClient) => 
 export function useTranslate(apiClient: SanityClient) {
   const [loading, setLoading] = useState(false)
   const user = useCurrentUser()
-  const schema = useSchema()
-  const types = useMemo(() => serializeSchema(schema, {leanFormat: true}), [schema])
+  const types = useSerializedTypes()
   const toast = useToast()
 
   const translate = useCallback(
@@ -126,8 +125,7 @@ export function useTranslate(apiClient: SanityClient) {
 export function useGenerateCaption(apiClient: SanityClient) {
   const [loading, setLoading] = useState(false)
   const user = useCurrentUser()
-  const schema = useSchema()
-  const types = useMemo(() => serializeSchema(schema, {leanFormat: true}), [schema])
+  const types = useSerializedTypes()
   const toast = useToast()
 
   const generateCaption = useCallback(
@@ -179,8 +177,7 @@ export function useGenerateCaption(apiClient: SanityClient) {
 export function useGenerateImage(apiClient: SanityClient) {
   const [loading, setLoading] = useState(false)
   const user = useCurrentUser()
-  const schema = useSchema()
-  const types = useMemo(() => serializeSchema(schema, {leanFormat: true}), [schema])
+  const types = useSerializedTypes()
   const toast = useToast()
 
   const generateImage = useCallback(
@@ -280,8 +277,7 @@ export function useRunInstructionApi(apiClient: SanityClient) {
   const toast = useToast()
   const [loading, setLoading] = useState(false)
   const user = useCurrentUser()
-  const schema = useSchema()
-  const types = useMemo(() => serializeSchema(schema, {leanFormat: true}), [schema])
+  const types = useSerializedTypes()
 
   const {
     config: {assist: assistConfig},


### PR DESCRIPTION
### Description

The hooks for making requests to the backend where each serializing the schema. Although this only happens on document load, it adds up in large schemas, as field actions will use these hooks, so every field was effectifly running the same code.

We now do this once and put the serialize schema in context, which significantly improves initial document load times in large document schemas.

