### PR TITLE
fix: includes visible conditional fields in non-conditional fieldsets

### DIFF
--- a/plugin/src/helpers/conditionalMembers.test.ts
+++ b/plugin/src/helpers/conditionalMembers.test.ts
@@ -227,6 +227,49 @@ describe('conditionalMembers', () => {
     ])
   })
 
+  test('should include field with conditional state inside fieldset', () => {
+    const docSchema: ObjectSchemaType = Schema.compile({
+      name: 'test',
+      types: [
+        defineType({
+          type: 'document',
+          name: 'article',
+          fieldsets: [{name: 'set'}],
+          fields: [{type: 'string', fieldset: 'set', name: 'title', hidden: () => false}],
+        }),
+      ],
+    }).get('article')
+
+    const docState = {
+      path: [],
+      schemaType: docSchema,
+      members: [
+        {
+          kind: 'fieldSet',
+          fieldSet: {
+            name: 'set',
+            path: ['set'],
+            members: [
+              {
+                kind: 'field',
+                field: {path: [docSchema.fields[0].name], schemaType: docSchema.fields[0].type},
+              },
+            ],
+          },
+        },
+      ],
+    } as any
+    const conditionalMembers = getConditionalMembers(docState)
+
+    expect(conditionalMembers).toEqual([
+      {
+        path: 'title',
+        hidden: false,
+        readOnly: false,
+      },
+    ])
+  })
+
   test('should respect max-depth', () => {
     const docSchema: ObjectSchemaType = Schema.compile({
       name: 'test',

--- a/plugin/src/helpers/conditionalMembers.ts
+++ b/plugin/src/helpers/conditionalMembers.ts
@@ -67,8 +67,8 @@ function conditionalState(memberState: {
 }): ConditionalMemberInnerState {
   return {
     path: pathToString(memberState.path),
-    readOnly: !!memberState.readOnly,
-    hidden: false, // if its in members, its not hidden
+    readOnly: !!memberState.readOnly, // Use actual form state readOnly value
+    hidden: false, // If it's in form state members, it's not hidden
     conditional: isConditional(memberState.schemaType),
   }
 }
@@ -124,7 +124,7 @@ function extractConditionalPaths(
       const innerFields = extractConditionalPaths(member.fieldSet, maxDepth).map((f) => ({
         ...f,
         // if fieldset is conditional, visible fields must also be considered conditional
-        conditional: conditionalFieldset ?? f.conditional,
+        conditional: conditionalFieldset || f.conditional,
       }))
       return [...acc, ...innerFields]
     }


### PR DESCRIPTION
### Description

Conditional fields inside fieldsets did not get their conditional state passed to the backend.

This fixes a bug in the code, where the "is the field condtional" logic shortcircuited if the fieldset was non-conditional. Now both the fieldset AND the field has to be non-conditional for the field to be considered non-conditional.


### Testing

Covered by the unit test.
